### PR TITLE
First cut at creating models and login interfaces for MFA

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,3 +3,6 @@ name: MFAAuthenticator
 After:
   - #coresecurity
 ---
+SilverStripe\Security\Member:
+  extensions:
+    mfaExtension: SilverStripe\MFA\Extensions\MemberExtension

--- a/src/AuthenticationMethod/AuthenticatorInterface.php
+++ b/src/AuthenticationMethod/AuthenticatorInterface.php
@@ -1,0 +1,37 @@
+<?php
+namespace SilverStripe\MFA\AuthenticationMethod;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\MFA\SessionStore;
+
+interface AuthenticatorInterface
+{
+    /**
+     * Prepare this authentication method to verify a member by initialising state in session and generating details to
+     * provide to a frontend React component
+     *
+     * @param SessionStore $store An object that hold session data (and the Member) that can be mutated
+     * @return array Props to be passed to a front-end React component
+     */
+    public function start(SessionStore $store);
+
+    /**
+     * Verify the request has provided the right information to verify the member that aligns with any sessions state
+     * that may have been set prior
+     *
+     * @param HTTPRequest $request
+     * @param SessionStore $store
+     * @return bool
+     */
+    public function verify(HTTPRequest $request, SessionStore $store);
+
+    /**
+     * Provide a string (possibly passed through i18n) that serves as a lead in for choosing this option for
+     * authentication
+     *
+     * eg. "Enter one of your recovery codes"
+     *
+     * @return string
+     */
+    public function getLeadInLabel();
+}

--- a/src/AuthenticationMethodInterface.php
+++ b/src/AuthenticationMethodInterface.php
@@ -1,0 +1,16 @@
+<?php
+namespace SilverStripe\MFA;
+
+use SilverStripe\MFA\AuthenticationMethod\AuthenticatorInterface;
+
+interface AuthenticationMethodInterface
+{
+    /**
+     * Return the authenticator interface that is used to start and verify login attempts with this method
+     *
+     * @return AuthenticatorInterface
+     */
+    public function getAuthenticator();
+
+    public function getRegistrar();
+}

--- a/src/BasicMath/Method.php
+++ b/src/BasicMath/Method.php
@@ -1,0 +1,23 @@
+<?php
+namespace SilverStripe\MFA\BasicMath;
+
+use SilverStripe\MFA\AuthenticationMethod\AuthenticatorInterface;
+use SilverStripe\MFA\AuthenticationMethodInterface;
+
+class Method implements AuthenticationMethodInterface
+{
+    /**
+     * Return the authenticator interface that is used to start and verify login attempts with this method
+     *
+     * @return AuthenticatorInterface
+     */
+    public function getAuthenticator()
+    {
+        return new MethodAuthenticator();
+    }
+
+    public function getRegistrar()
+    {
+        // TODO: Implement getRegistrar() method.
+    }
+}

--- a/src/BasicMath/MethodAuthenticator.php
+++ b/src/BasicMath/MethodAuthenticator.php
@@ -1,0 +1,65 @@
+<?php
+namespace SilverStripe\MFA\BasicMath;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\MFA\AuthenticationMethod\AuthenticatorInterface;
+use SilverStripe\MFA\SessionStore;
+
+class MethodAuthenticator implements AuthenticatorInterface
+{
+    use Configurable;
+
+    private static $number_of_numbers = 2;
+
+    /**
+     * Prepare this authentication method to verify a member by initialising state in session and generating details to
+     * provide to a frontend React component
+     *
+     * @param SessionStore $store An object that hold session data (and the Member) that can be mutated
+     * @return array Props to be passed to a front-end React component
+     */
+    public function start(SessionStore $store)
+    {
+        $numbers = [];
+
+        for ($i = 0; $i < static::config()->get('number_of_numbers'); $i++) {
+            $numbers[] = rand(1, 9);
+        }
+
+        $store->setState([
+            'answer' => array_sum($numbers),
+        ]);
+
+        return [
+            'numbers' => $numbers,
+        ];
+    }
+
+    /**
+     * Verify the request has provided the right information to verify the member that aligns with any sessions state
+     * that may have been set prior
+     *
+     * @param HTTPRequest $request
+     * @param SessionStore $store
+     * @return bool
+     */
+    public function verify(HTTPRequest $request, SessionStore $store)
+    {
+        $state = $store->getState();
+        return hash_equals($state['answer'], $request->param('answer'));
+    }
+
+    /**
+     * Provide a string (possibly passed through i18n) that serves as a lead in for choosing this option for
+     * authentication
+     *
+     * eg. "Enter one of your recovery codes"
+     *
+     * @return string
+     */
+    public function getLeadInLabel()
+    {
+        return 'Verify by solving a complex math problem';
+    }
+}

--- a/src/Extensions/MemberExtension.php
+++ b/src/Extensions/MemberExtension.php
@@ -1,0 +1,23 @@
+<?php
+namespace SilverStripe\MFA\Extensions;
+
+use SilverStripe\MFA\Model\AuthenticationMethod;
+use SilverStripe\ORM\DataExtension;
+
+/**
+ * Extend Member to add relationship to authentication methods and track some specific preferences
+ *
+ * @package SilverStripe\MFA
+ * @method AuthenticationMethod[] AuthenticationMethods
+ * @property string DefaultAuthenticationMethod
+ */
+class MemberExtension extends DataExtension
+{
+    private static $has_many = [
+        'AuthenticationMethods' => AuthenticationMethod::class,
+    ];
+
+    private static $db = [
+        'DefaultAuthenticationMethod' => 'Varchar',
+    ];
+}

--- a/src/LoginHandler.php
+++ b/src/LoginHandler.php
@@ -1,0 +1,261 @@
+<?php
+namespace SilverStripe\MFA;
+
+use LogicException;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\MFA\Extensions\MemberExtension;
+use SilverStripe\MFA\Model\AuthenticationMethod;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\MemberAuthenticator\LoginHandler as BaseLoginHandler;
+use SilverStripe\Security\MemberAuthenticator\MemberLoginForm;
+
+class LoginHandler extends BaseLoginHandler
+{
+    const SESSION_KEY = 'MFALogin';
+
+    private static $url_handlers = [
+        'mfa/start/$Method' => 'start',
+        'mfa/verify' => 'verify',
+        'mfa' => 'mfa',
+    ];
+
+    private static $allowed_actions = [
+        'mfa',
+        'startMethod',
+    ];
+
+    /**
+     * Indicate how many MFA methods the user must authenticate with before they are considered logged in
+     *
+     * @config
+     * @var int
+     */
+    private static $required_mfa_methods = 1;
+
+    /**
+     * A "session store" object that helps contain MFA specific session detail
+     *
+     * @var SessionStore
+     */
+    protected $sessionStore;
+
+    /**
+     * Override the parent "doLogin" to insert extra steps into the flow
+     *
+     * @inheritdoc
+     */
+    public function doLogin($data, MemberLoginForm $form, HTTPRequest $request)
+    {
+        $member = $this->checkLogin($data, $request, $result);
+
+        // If there's no member it's an invalid login. We'll delegate this to the parent
+        if (!$member) {
+            return parent::doLogin($data, $form, $request);
+        }
+
+        // Store a reference to the member in session
+        $this->getSessionStore()->setMember($member);
+        $this->getSessionStore()->save($request);
+
+        // Store the BackURL for use after the process is complete
+        if (!empty($data)) {
+            $request->getSession()->set(static::SESSION_KEY . '.additionalData', $data);
+        }
+
+        // Redirect to the MFA step
+        return $this->redirect($this->link('mfa'));
+    }
+
+    /**
+     * Action handler for displaying the MFA authentication React app
+     *
+     * @return array|HTTPResponse
+     */
+    public function mfa()
+    {
+        $member = $this->getSessionStore()->getMember();
+
+        // If we don't have a valid member we shouldn't be here...
+        if (!$member) {
+            return $this->redirectBack();
+        }
+
+        // Get a list of authentication for the user and the find default
+        $authMethods = $member->AuthenticationMethods();
+
+        // Pool a list of "lead in" labels. We skip the default here assuming it's not required.
+        $alternateLeadInLabels = [];
+        foreach ($authMethods as $method) {
+            $alternateLeadInLabels[str_replace('\\', '-', get_class($method))] =
+                $method->getAuthenticator()->getLeadInLabel();
+        }
+
+        return [
+            'methods' => $alternateLeadInLabels,
+        ];
+    }
+
+    /**
+     * Handles the request to start an authentication process with an authenticator (possibly specified by the request)
+     *
+     * @param HTTPRequest $request
+     * @return HTTPResponse
+     */
+    public function start(HTTPRequest $request)
+    {
+        $sessionStore = $this->getSessionStore();
+        $member = $sessionStore->getMember();
+
+        // If we don't have a valid member we shouldn't be here...
+        if (!$member) {
+            return $this->redirectBack();
+        }
+
+        // Pull a method to use from the request or use the default
+        $specifiedMethod = str_replace('-', '\\', $request->param('Method')) ?: $member->DefaultAuthenticationMethod;
+        list($method, $candidate) = $this->getMethodFromMember($member, $specifiedMethod);
+
+        // Mark the given method as started within the session
+        $sessionStore->setMethod($candidate->MethodClassName);
+        // Allow the authenticator to begin the process and generate some data to pass through to the front end
+        $data = $method->getAuthenticator()->start($sessionStore);
+        // Ensure detail is saved to the session
+        $sessionStore->save($request);
+
+        // Respond with our method
+        return $this->jsonResponse($data);
+    }
+
+    public function verify(HTTPRequest $request)
+    {
+        $method = $this->getSessionStore()->getMethod();
+
+        // We must've been to a "start" and set the method being used in session here.
+        if (!$method) {
+            return $this->redirectBack();
+        }
+
+        // Get the member and authenticator ready
+        $member = $this->getSessionStore()->getMember();
+        $authenticator = $this->getMethodFromMember($member, $method)->getAuthenticator();
+
+        if (!$authenticator->verify($request, $this->getSessionStore())) {
+            // TODO figure out how to return a message here too.
+            return $this->redirect($this->link('mfa'));
+        }
+
+        $this->addSuccessfulVerification($request, $method);
+
+        if (!$this->isLoginComplete($request)) {
+            return $this->redirect($this->link('mfa'));
+        }
+
+        // Load the previously stored data from session and perform the login using it...
+        $data = $request->getSession()->get(static::SESSION_KEY . '.additionalData');
+        $this->performLogin($member, $data, $request);
+
+        // Clear session...
+        SessionStore::clear($request);
+        $request->getSession()->clear(static::SESSION_KEY . '.additionalData');
+        $request->getSession()->clear(static::SESSION_KEY . '.successfulMethods');
+
+        // Redirecting after successful login expects a getVar to be set
+        if (!empty($data['BackURL'])) {
+            $request->BackURL = $data['BackURL'];
+        }
+        return $this->redirectAfterSuccessfulLogin();
+    }
+
+    /**
+     * Respond with the given array as a JSON response
+     *
+     * @param array $response
+     * @return HTTPResponse
+     */
+    protected function jsonResponse(array $response)
+    {
+        return HTTPResponse::create(json_encode($response))->addHeader('Content-Type', 'application/json');
+    }
+
+    /**
+     * Indicate that the user has successfully verifed the given authentication method
+     *
+     * @param string $method The method class name
+     */
+    protected function addSuccessfulVerification(HTTPRequest $request, $method)
+    {
+        // Pull the prior sucesses from the session
+        $key = static::SESSION_KEY . '.successfulMethods';
+        $successfulMethods = $request->getSession()->get($key);
+
+        // Coalesce these methods
+        if (!$successfulMethods) {
+            $successfulMethods = [];
+        }
+
+        // Add our new success
+        $successfulMethods[] = $method;
+
+        // Ensure it's persisted in session
+        $request->getSession()->set($key, $successfulMethods);
+
+        return $this;
+    }
+
+    protected function isLoginComplete(HTTPRequest $request)
+    {
+        // Pull the successful methods from session
+        $successfulMethods = $request->getSession()->get(static::SESSION_KEY . '.successfulMethods');
+
+        // Zero is "not complete". There's different config for optional MFA
+        if (!is_array($successfulMethods) || !count($successfulMethods)) {
+            return false;
+        }
+
+        return count($successfulMethods) >= static::config()->get('required_mfa_methods');
+    }
+
+    /**
+     * @return SessionStore
+     */
+    protected function getSessionStore()
+    {
+        if (!$this->sessionStore) {
+            $this->sessionStore = SessionStore::create($this->getRequest());
+        }
+
+        return $this->sessionStore;
+    }
+
+    /**
+     * Get an authentication method object matching the given method from the given member.
+     *
+     * @param Member|MemberExtension $member
+     * @param string $specifiedMethod
+     * @return AuthenticationMethodInterface
+     */
+    protected function getMethodFromMember(Member $member, $specifiedMethod)
+    {
+        $method = null;
+
+        // Find the actual method registration data object from the member for the specified default authenticator
+        foreach ($member->AuthenticationMethods() as $candidate) {
+            if ($candidate->MethodClassName === $specifiedMethod) {
+                $method = $candidate;
+                break;
+            }
+        }
+
+        // In this scenario the member has managed to set a default authenticator that has no registration.
+        if (!$method) {
+            throw new LogicException(sprintf(
+                'There is no authenticator registered for this member that matches the requested method ("%s")',
+                $specifiedMethod
+            ));
+        }
+
+        return $method;
+    }
+}

--- a/src/MemberAuthenticator.php
+++ b/src/MemberAuthenticator.php
@@ -1,0 +1,12 @@
+<?php
+namespace SilverStripe\MFA;
+
+use SilverStripe\Security\MemberAuthenticator\MemberAuthenticator as BaseMemberAuthenticator;
+
+class MemberAuthenticator extends BaseMemberAuthenticator
+{
+    public function getLoginHandler($link)
+    {
+        return LoginHandler::create($link, $this);
+    }
+}

--- a/src/Model/AuthenticationMethod.php
+++ b/src/Model/AuthenticationMethod.php
@@ -1,0 +1,83 @@
+<?php
+namespace SilverStripe\MFA\Model;
+
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\MFA\AuthenticationMethod\AuthenticatorInterface;
+use SilverStripe\MFA\AuthenticationMethodInterface;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Member;
+
+/**
+ * @package SilverStripe\MFA\Model
+ *
+ * @property string MethodClassName
+ * @property array Data
+ */
+class AuthenticationMethod extends DataObject
+{
+    private static $table_name = 'MFAAuthenticationMethod';
+
+    private static $db = [
+        // The class name of the AuthenticationMethodInterface that this record refers to
+        'MethodClassName' => 'Varchar',
+        // Data stored as a JSON blob that may contain detail specific to this registration of the authenticator
+        'Data' => 'Text',
+    ];
+
+    private static $has_one = [
+        'Member' => Member::class,
+    ];
+
+    /**
+     * @var AuthenticationMethodInterface
+     */
+    protected $method;
+
+    /**
+     * @return AuthenticatorInterface
+     */
+    public function getAuthenticator()
+    {
+        return $this->getMethod()->getAuthenticator();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getRegistrar()
+    {
+        return $this->getMethod()->getRegistrar();
+    }
+
+    /**
+     * Accessor for Data field to ensure it's presented as an array instead of a JSON blob
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        return (array) json_decode($this->getField('Data'), true);
+    }
+
+    /**
+     * Setter for the Data field to ensure it's saved as a JSON blob
+     *
+     * @param mixed $data
+     */
+    public function setData($data)
+    {
+        $this->setField('Data', json_encode($data));
+    }
+
+    /**
+     * @return AuthenticationMethodInterface
+     */
+    protected function getMethod()
+    {
+        if (!$this->method) {
+            $this->method = Injector::inst()->create($this->MethodClassName);
+        }
+
+        return $this->method;
+    }
+}

--- a/src/SessionStore.php
+++ b/src/SessionStore.php
@@ -1,0 +1,158 @@
+<?php
+namespace SilverStripe\MFA;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\MFA\Extensions\MemberExtension;
+use SilverStripe\Security\Member;
+
+/**
+ * This class provides an interface to store data in session during an MFA process. This is implemented as a measure to
+ * prevent bleeding state between individual MFA auth types
+ *
+ * @package SilverStripe\MFA
+ */
+class SessionStore
+{
+    const SESSION_KEY = 'thing';
+
+    /**
+     * The member that is currently going through the MFA process
+     *
+     * @var Member
+     */
+    protected $member;
+
+    /**
+     * A string representing the current authentication method that is underway
+     *
+     * @var string
+     */
+    protected $method;
+
+    /**
+     * Any state that the current authentication method needs to retain while it is underway
+     *
+     * @var array
+     */
+    protected $state = [];
+
+    /**
+     * Create a store from the given request getting any initial state from the session of the request
+     *
+     * @param HTTPRequest $request
+     * @return SessionStore
+     */
+    public static function create(HTTPRequest $request)
+    {
+        $state = $request->getSession()->get(static::SESSION_KEY);
+
+        $new = new static;
+
+        if ($state) {
+            $new->setMethod($state['method']);
+            $new->setState($state['state']);
+            if ($state['member']) {
+                $new->setMember(Member::get_by_id($state['member']));
+            }
+        }
+
+        return $new;
+    }
+
+    /**
+     * @return Member|MemberExtension
+     */
+    public function getMember()
+    {
+        return $this->member;
+    }
+
+    /**
+     * @param Member $member
+     * @return $this
+     */
+    public function setMember(Member $member)
+    {
+        // Early return if there's no change
+        if ($this->member && $this->member->ID === $member->ID) {
+            return $this;
+        }
+
+        // If the member has changed we should null out the method that's underway and the state of it
+        $this->resetMethod();
+
+        $this->member = $member;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+
+    /**
+     * @param string $method
+     * @return $this
+     */
+    public function setMethod($method)
+    {
+        $this->method = $method;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    /**
+     * @param array $state
+     * @return $this
+     */
+    public function setState(array $state)
+    {
+        $this->state = $state;
+
+        return $this;
+    }
+
+    /**
+     * Save this store into the session of the given request
+     *
+     * @param HTTPRequest $request
+     * @return $this
+     */
+    public function save(HTTPRequest $request)
+    {
+        $request->getSession()->set(static::SESSION_KEY, $this->build());
+
+        return $this;
+    }
+
+    public static function clear(HTTPRequest $request)
+    {
+        $request->getSession()->clear(static::SESSION_KEY);
+    }
+
+    protected function resetMethod()
+    {
+        $this->setMethod(null)->setState([]);
+    }
+
+    protected function build()
+    {
+        return [
+            'member' => $this->getMember() ? $this->getMember()->ID : null,
+            'method' => $this->getMethod(),
+            'state' => $this->getState(),
+        ];
+    }
+}


### PR DESCRIPTION
- Adds a MemberAuthenticator that overrides the LoginHandler
- Extends the base MemberAuthenticator LoginHandler to insert another step into the login process
- Creates a model for registering MFA methods - hasMany on a Member
  - Stores the type of MFA method
  - Holds additional arbitrary data as a blob for that specific registration of the MFA method
- Creates a MemberExtension for storing some detail on Member
- Adds a "BasicMath" MFA method for testing and POC

I've taken the liberty of deciding to create a `SessionStore` class that is used for containing state an MFA method stores in the session. I've done this for a few reasons:
- Keeps state added to the session by plug-in modules contained. Prevents bleeding state between authenticators
- Allows the base MFA module to reliably clear detail that a method may store in session
- Provide a nicer interface for storing some of the data in session.

This can be somewhat tested by adding the configuration:

```
SilverStripe\Core\Injector\Injector:
  SilverStripe\Security\Security:
    properties:
      Authenticators:
        default: %$SilverStripe\MFA\MemberAuthenticator
```

And logging in as usual. You will have to manually register a MFA method. You can do this by:

```php
$method = AuthenticationMethod::create(['MethodClassName' => BasicMath\Method::class]);
$method->Member = $member;
$method->write();
```

The login process automatically takes you to `login/default/mfa` which is rendered with a template (and just shows a blank page below a "login" title). There's also a `login/default/mfa/start/$Method` end
point where you can "start" an MFA process. Try `login/default/mfa/start/SilverStripe-MFA-BasicMath-Method` :wink:

I'm also open to suggestions about naming and directory structure. I'm not sold yet...

I also didn't test the flow at all from `verify` onwards... Sorry!