### PR TITLE
NEW The MFA schema endpoint now returns relevant details

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,6 +3,14 @@ name: MFAAuthenticator
 After:
   - #coresecurity
 ---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Security\Security:
+    properties:
+      Authenticators:
+        default: %$SilverStripe\MFA\Authenticator\MemberAuthenticator
+---
+name: MFAMemberExtension
+---
 SilverStripe\Security\Member:
   extensions:
     mfaExtension: SilverStripe\MFA\Extension\MemberExtension

--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -1,14 +1,10 @@
 <?php
 namespace SilverStripe\MFA\Authenticator;
 
-use LogicException;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\MFA\Extension\MemberExtension;
-use SilverStripe\MFA\Model\RegisteredMethod;
 use SilverStripe\MFA\Service\MethodRegistry;
 use SilverStripe\MFA\Store\SessionStore;
-use SilverStripe\Security\Member;
 use SilverStripe\Security\MemberAuthenticator\LoginHandler as BaseLoginHandler;
 use SilverStripe\Security\MemberAuthenticator\MemberLoginForm;
 
@@ -59,7 +55,8 @@ class LoginHandler extends BaseLoginHandler
         $member = $this->checkLogin($data, $request, $result);
 
         // If there's no member it's an invalid login. We'll delegate this to the parent
-        if (!$member) {
+        // Additionally if there are no MFA methods registered then we will also delegate
+        if (!$member || !$this->getMethodRegistry()->areMethodsAvailable()) {
             return parent::doLogin($data, $form, $request);
         }
 
@@ -181,7 +178,7 @@ class LoginHandler extends BaseLoginHandler
 
         // Pull a method to use from the request or use the default (TODO: Should we have the default as a fallback?)
         $specifiedMethod = str_replace('-', '\\', $request->param('Method')) ?: $member->DefaultRegisteredMethod;
-        $method = $this->getMethodFromMember($member, $specifiedMethod);
+        $method = $this->getMethodRegistry()->getMethodFromMember($member, $specifiedMethod);
 
         // Mark the given method as started within the session
         $sessionStore->setMethod($method->MethodClassName);
@@ -211,7 +208,7 @@ class LoginHandler extends BaseLoginHandler
 
         // Get the member and authenticator ready
         $member = $this->getSessionStore()->getMember();
-        $authenticator = $this->getMethodFromMember($member, $method)->getLoginHandler();
+        $authenticator = $this->getMethodRegistry()->getMethodFromMember($member, $method)->getLoginHandler();
 
         if (!$authenticator->verify($request, $this->getSessionStore())) {
             // TODO figure out how to return a message here too.
@@ -306,32 +303,12 @@ class LoginHandler extends BaseLoginHandler
     }
 
     /**
-     * Get an authentication method object matching the given method from the given member.
+     * Helper method for getting an instance of a method registry
      *
-     * @param Member|MemberExtension $member
-     * @param string $specifiedMethod
-     * @return RegisteredMethod
+     * @return MethodRegistry
      */
-    protected function getMethodFromMember(Member $member, $specifiedMethod)
+    protected function getMethodRegistry()
     {
-        $method = null;
-
-        // Find the actual method registration data object from the member for the specified default authenticator
-        foreach ($member->RegisteredMFAMethods() as $candidate) {
-            if ($candidate->MethodClassName === $specifiedMethod) {
-                $method = $candidate;
-                break;
-            }
-        }
-
-        // In this scenario the member has managed to set a default authenticator that has no registration.
-        if (!$method) {
-            throw new LogicException(sprintf(
-                'There is no authenticator registered for this member that matches the requested method ("%s")',
-                $specifiedMethod
-            ));
-        }
-
-        return $method;
+        return MethodRegistry::singleton();
     }
 }

--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -56,7 +56,7 @@ class LoginHandler extends BaseLoginHandler
 
         // If there's no member it's an invalid login. We'll delegate this to the parent
         // Additionally if there are no MFA methods registered then we will also delegate
-        if (!$member || !$this->getMethodRegistry()->areMethodsAvailable()) {
+        if (!$member || !$this->getMethodRegistry()->hasMethods()) {
             return parent::doLogin($data, $form, $request);
         }
 
@@ -111,7 +111,7 @@ class LoginHandler extends BaseLoginHandler
         $registeredMethodNames = array_keys($alternateLeadInLabels);
 
         // Get all methods that may be registered
-        $allMethods = MethodRegistry::singleton()->getAllMethods();
+        $allMethods = MethodRegistry::singleton()->getMethods();
 
         // Resolve details for methods that aren't setup
         foreach ($allMethods as $method) {

--- a/src/Extension/MemberExtension.php
+++ b/src/Extension/MemberExtension.php
@@ -1,14 +1,19 @@
 <?php
 namespace SilverStripe\MFA\Extension;
 
+use SilverStripe\MFA\Method\MethodInterface;
 use SilverStripe\MFA\Model\RegisteredMethod;
 use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\HasManyList;
+use SilverStripe\Security\Member;
 
 /**
  * Extend Member to add relationship to registered methods and track some specific preferences
  *
- * @method RegisteredMethod[] RegisteredMFAMethods
- * @property string DefaultRegisteredMethod
+ * @method RegisteredMethod[]|HasManyList RegisteredMFAMethods
+ * @property MethodInterface DefaultRegisteredMethod
+ * @property string DefaultRegisteredMethodID
+ * @property Member|MemberExtension owner
  */
 class MemberExtension extends DataExtension
 {
@@ -17,6 +22,19 @@ class MemberExtension extends DataExtension
     ];
 
     private static $db = [
-        'DefaultRegisteredMethod' => 'Varchar',
+        'DefaultRegisteredMethodID' => 'Int',
     ];
+
+    /**
+     * Accessor for the `DefaultRegisteredMethod` property
+     *
+     * This is replicating the usual functionality of a has_one relation but does it like this so we can ensure the same
+     * instance of the MethodInterface is provided regardless if you access it through the has_one or the has_many.
+     *
+     * @return MethodInterface
+     */
+    public function getDefaultRegisteredMethod()
+    {
+        return $this->owner->RegisteredMFAMethods()->byId($this->owner->DefaultRegisteredMethodID);
+    }
 }

--- a/src/Method/MethodInterface.php
+++ b/src/Method/MethodInterface.php
@@ -11,6 +11,13 @@ use SilverStripe\MFA\Method\Handler\RegisterHandlerInterface;
 interface MethodInterface
 {
     /**
+     * Get a URL segment for this method. This will be used in URL paths for performing authentication by this method
+     *
+     * @return string
+     */
+    public function getURLSegment();
+
+    /**
      * Return the LoginHandler that is used to start and verify login attempts with this method
      *
      * @return LoginHandlerInterface

--- a/src/Model/RegisteredMethod.php
+++ b/src/Model/RegisteredMethod.php
@@ -35,6 +35,18 @@ class RegisteredMethod extends DataObject
     protected $method;
 
     /**
+     * @return MethodInterface
+     */
+    public function getMethod()
+    {
+        if (!$this->method) {
+            $this->method = Injector::inst()->create($this->MethodClassName);
+        }
+
+        return $this->method;
+    }
+
+    /**
      * @return LoginHandlerInterface
      */
     public function getLoginHandler()
@@ -68,17 +80,5 @@ class RegisteredMethod extends DataObject
     public function setData($data)
     {
         $this->setField('Data', json_encode($data));
-    }
-
-    /**
-     * @return MethodInterface
-     */
-    protected function getMethod()
-    {
-        if (!$this->method) {
-            $this->method = Injector::inst()->create($this->MethodClassName);
-        }
-
-        return $this->method;
     }
 }

--- a/src/Service/MethodRegistry.php
+++ b/src/Service/MethodRegistry.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SilverStripe\MFA\Service;
+
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\MFA\Method\MethodInterface;
+use UnexpectedValueException;
+
+/**
+ * A service class that holds the configuration for enabled MFA methods and facilitates providing these methods
+ */
+class MethodRegistry
+{
+    use Configurable;
+    use Injectable;
+
+    /**
+     * List of configured MFA methods. These should be class names that implement MethodInterface
+     *
+     * @config
+     * @var array
+     */
+    private static $methods;
+
+    /**
+     * Get implementations of all configured methods
+     *
+     * @return MethodInterface[]
+     */
+    public function getAllMethods()
+    {
+        $configuredMethods = (array) static::config()->get('methods');
+
+        $allMethods = [];
+
+        foreach ($configuredMethods as $method) {
+            $method = Injector::inst()->get($method);
+
+            if (!$method instanceof MethodInterface) {
+                throw new UnexpectedValueException(sprintf(
+                    'Given method "%s" does not implement %s',
+                    $method,
+                    MethodInterface::class
+                ));
+            }
+
+            $allMethods[] = $method;
+        }
+
+        return $allMethods;
+    }
+}

--- a/src/Service/MethodRegistry.php
+++ b/src/Service/MethodRegistry.php
@@ -32,8 +32,9 @@ class MethodRegistry
      * Get implementations of all configured methods
      *
      * @return MethodInterface[]
+     * @throws UnexpectedValueException When an invalid method is registered
      */
-    public function getAllMethods()
+    public function getMethods()
     {
         $configuredMethods = (array) static::config()->get('methods');
 
@@ -61,17 +62,18 @@ class MethodRegistry
      *
      * @return bool
      */
-    public function areMethodsAvailable()
+    public function hasMethods()
     {
-        return count($this->getAllMethods()) > 0;
+        return count($this->getMethods()) > 0;
     }
 
     /**
-     * Get an authentication method object matching the given method from the given member.
+     * Get an authentication method object matching the given method from the given member. Returns null if the given
+     * method could not be found attached to the Member
      *
      * @param Member|MemberExtension $member
-     * @param string $specifiedMethod
-     * @return RegisteredMethod
+     * @param string $specifiedMethod The class name of the requested method
+     * @return RegisteredMethod|null
      */
     public function getMethodFromMember(Member $member, $specifiedMethod)
     {
@@ -83,14 +85,6 @@ class MethodRegistry
                 $method = $candidate;
                 break;
             }
-        }
-
-        // In this scenario the member has managed to set a default authenticator that has no registration.
-        if (!$method) {
-            throw new LogicException(sprintf(
-                'There is no authenticator registered for this member that matches the requested method ("%s")',
-                $specifiedMethod
-            ));
         }
 
         return $method;

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -3,6 +3,7 @@ namespace SilverStripe\MFA\Store;
 
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\MFA\Extension\MemberExtension;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
 
 /**
@@ -51,7 +52,7 @@ class SessionStore implements StoreInterface
             $new->setMethod($state['method']);
             $new->setState($state['state']);
             if ($state['member']) {
-                $new->setMember(Member::get_by_id($state['member']));
+                $new->setMember(DataObject::get_by_id(Member::class, $state['member']));
             }
         }
 

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\Authenticator;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\MFA\Method\Handler\RegisterHandlerInterface;
+use SilverStripe\MFA\Method\MethodInterface;
+use SilverStripe\MFA\Model\RegisteredMethod;
+use SilverStripe\MFA\Service\MethodRegistry;
+use SilverStripe\MFA\Store\SessionStore;
+use SilverStripe\MFA\Tests\Stub\BasicMath\Method;
+use SilverStripe\Security\Member;
+
+class LoginHandlerTest extends FunctionalTest
+{
+    protected static $fixture_file = 'LoginHandlerTest.yml';
+
+    protected function setUp()
+    {
+        parent::setUp();
+        Config::modify()->set(MethodRegistry::class, 'methods', [Method::class]);
+    }
+
+    public function testMFASchemaEndpointIsNotAccessibleByDefault()
+    {
+        // Assert that this endpoint is not available if you haven't started the login process
+        $this->autoFollowRedirection = false;
+        $response = $this->get('Security/login/default/mfa/schema');
+
+        $this->assertSame(302, $response->getStatusCode());
+    }
+
+    public function testMFASchemaEndpointReturnsMethodDetails()
+    {
+        // "Guy" isn't very security conscious - he has no MFA methods set up
+        $member = $this->objFromFixture(Member::class, 'guy');
+        $this->scaffoldPartialLogin($member);
+
+        $result = $this->get('Security/login/default/mfa/schema');
+
+        $response = json_decode($result->getBody(), true);
+
+        $this->assertArrayHasKey('registeredMethods', $response);
+        $this->assertArrayHasKey('registrationDetails', $response);
+        $this->assertArrayHasKey('defaultMethod', $response);
+
+        $this->assertCount(0, $response['registeredMethods']);
+        $this->assertCount(1, $response['registrationDetails']);
+        $this->assertNull($response['defaultMethod']);
+
+        /** @var MethodInterface $method */
+        $method = Injector::inst()->get(Method::class);
+        $registerHandler = $method->getRegisterHandler();
+
+        $this->assertSame([$method->getURLSegment() => [
+            'name' => $registerHandler->getName(),
+            'description' => $registerHandler->getDescription(),
+            'supportLink' => $registerHandler->getSupportLink(),
+        ]], $response['registrationDetails']);
+    }
+
+    public function testMFASchemaEndpointShowsRegisteredMethodsIfSetUp()
+    {
+        // "Simon" is security conscious - he uses the cutting edge MFA methods
+        $member = $this->objFromFixture(Member::class, 'simon');
+        $this->scaffoldPartialLogin($member);
+
+        $result = $this->get('Security/login/default/mfa/schema');
+
+        $response = json_decode($result->getBody(), true);
+
+        $this->assertArrayHasKey('registeredMethods', $response);
+        $this->assertArrayHasKey('registrationDetails', $response);
+        $this->assertArrayHasKey('defaultMethod', $response);
+
+        $this->assertCount(1, $response['registeredMethods']);
+        $this->assertCount(0, $response['registrationDetails']);
+        $this->assertNull($response['defaultMethod']);
+
+        /** @var MethodInterface $method */
+        $method = Injector::inst()->get(Method::class);
+        $loginHandler = $method->getLoginHandler();
+
+        $this->assertSame(
+            [$method->getURLSegment() => $loginHandler->getLeadInLabel()],
+            $response['registeredMethods']
+        );
+    }
+
+    public function testMFASchemaEndpointProvidesDefaultMethodIfSet()
+    {
+        // "Robbie" is security conscious and is also a CMS expert! He set up MFA and set a default method :o
+        $member = $this->objFromFixture(Member::class, 'robbie');
+        $this->scaffoldPartialLogin($member);
+
+        $result = $this->get('Security/login/default/mfa/schema');
+
+        $response = json_decode($result->getBody(), true);
+
+        $this->assertArrayHasKey('registeredMethods', $response);
+        $this->assertArrayHasKey('registrationDetails', $response);
+        $this->assertArrayHasKey('defaultMethod', $response);
+
+        $this->assertCount(1, $response['registeredMethods']);
+        $this->assertCount(0, $response['registrationDetails']);
+
+        /** @var RegisteredMethod $mathMethod */
+        $mathMethod = $this->objFromFixture(RegisteredMethod::class, 'robbie-math');
+        $this->assertSame($mathMethod->getMethod()->getURLSegment(), $response['defaultMethod']);
+    }
+
+    /**
+     * Mark the given user as partially logged in - ie. they've entered their email/password and are currently going
+     * through the MFA process
+     * @param Member $member
+     */
+    protected function scaffoldPartialLogin(Member $member)
+    {
+        $this->logOut();
+
+        $this->session()->set(SessionStore::SESSION_KEY, [
+            'member' => $member->ID,
+            'method' => null,
+            'state' => [],
+        ]);
+    }
+}

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -25,7 +25,7 @@ class LoginHandlerTest extends FunctionalTest
         Config::modify()->set(MethodRegistry::class, 'methods', [Method::class]);
 
         Injector::inst()->load([
-            'SilverStripe\Security\Security' => [
+            Security::class => [
                 'properties' => [
                     'authenticators' => [
                         'default' => '%$' . MemberAuthenticator::class,
@@ -44,7 +44,7 @@ class LoginHandlerTest extends FunctionalTest
         $this->autoFollowRedirection = true;
 
         $this->assertSame(302, $response->getStatusCode());
-        $this->assertSame('http://localhost/Security/login/default/mfa', $response->getHeader('location'));
+        $this->assertStringEndsWith('/Security/login/default/mfa', $response->getHeader('location'));
     }
     
     public function testMethodsNotBeingAvailableWillLogin()
@@ -61,7 +61,7 @@ class LoginHandlerTest extends FunctionalTest
         $this->autoFollowRedirection = true;
 
         $this->assertSame(302, $response->getStatusCode());
-        $this->assertSame('http://localhost/something', $response->getHeader('location'));
+        $this->assertStringEndsWith('/something', $response->getHeader('location'));
     }
 
     public function testMFASchemaEndpointIsNotAccessibleByDefault()
@@ -179,7 +179,7 @@ class LoginHandlerTest extends FunctionalTest
         $this->get(Config::inst()->get(Security::class, 'login_url'));
 
         return $this->submitForm(
-            "MemberLoginForm_LoginForm",
+            'MemberLoginForm_LoginForm',
             null,
             array(
                 'Email' => $member->Email,

--- a/tests/php/Authenticator/LoginHandlerTest.yml
+++ b/tests/php/Authenticator/LoginHandlerTest.yml
@@ -1,0 +1,17 @@
+SilverStripe\MFA\Model\RegisteredMethod:
+  simon-math:
+    MethodClassName: "SilverStripe\\MFA\\Tests\\Stub\\BasicMath\\Method"
+  robbie-math:
+    MethodClassName: "SilverStripe\\MFA\\Tests\\Stub\\BasicMath\\Method"
+
+SilverStripe\Security\Member:
+  guy:
+    Email: guy@example.com
+  simon:
+    Email: simon@example.com
+    RegisteredMFAMethods: =>SilverStripe\MFA\Model\RegisteredMethod.simon-math
+  robbie:
+    Email: robbie@example.com
+    RegisteredMFAMethods: =>SilverStripe\MFA\Model\RegisteredMethod.robbie-math
+    DefaultRegisteredMethodID: =>SilverStripe\MFA\Model\RegisteredMethod.robbie-math
+

--- a/tests/php/Authenticator/LoginHandlerTest.yml
+++ b/tests/php/Authenticator/LoginHandlerTest.yml
@@ -7,6 +7,8 @@ SilverStripe\MFA\Model\RegisteredMethod:
 SilverStripe\Security\Member:
   guy:
     Email: guy@example.com
+    Password: Password123
+    PasswordExpiry: 2030-01-01
   simon:
     Email: simon@example.com
     RegisteredMFAMethods: =>SilverStripe\MFA\Model\RegisteredMethod.simon-math

--- a/tests/php/Service/MethodRegistryTest.php
+++ b/tests/php/Service/MethodRegistryTest.php
@@ -22,8 +22,10 @@ class MethodRegistryTest extends SapphireTest
     }
 
     /**
+     * phpcs:disable
      * @expectedException UnexpectedValueException
      * @expectedExceptionMessage Given method "SilverStripe\Security\Member" does not implement SilverStripe\MFA\Method\MethodInterface
+     * phpcs:enable
      */
     public function testInvalidMethodsThrowExceptions()
     {

--- a/tests/php/Service/MethodRegistryTest.php
+++ b/tests/php/Service/MethodRegistryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\Service;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\MFA\Service\MethodRegistry;
+use SilverStripe\MFA\Tests\Stub\BasicMath\Method;
+use SilverStripe\Security\Member;
+use UnexpectedValueException;
+
+class MethodRegistryTest extends SapphireTest
+{
+    public function testGetAllMethodsReturnsRegisteredMethods()
+    {
+        Config::modify()->set(MethodRegistry::class, 'methods', [Method::class]);
+        $registry = MethodRegistry::singleton();
+        $methods = $registry->getAllMethods();
+
+        $this->assertCount(1, $methods);
+        $this->assertInstanceOf(Method::class, reset($methods));
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     * @expectedExceptionMessage Given method "SilverStripe\Security\Member" does not implement SilverStripe\MFA\Method\MethodInterface
+     */
+    public function testInvalidMethodsThrowExceptions()
+    {
+        Config::modify()->set(MethodRegistry::class, 'methods', [Member::class]);
+        $registry = MethodRegistry::singleton();
+        $registry->getAllMethods();
+    }
+}

--- a/tests/php/Service/MethodRegistryTest.php
+++ b/tests/php/Service/MethodRegistryTest.php
@@ -15,7 +15,7 @@ class MethodRegistryTest extends SapphireTest
     {
         Config::modify()->set(MethodRegistry::class, 'methods', [Method::class]);
         $registry = MethodRegistry::singleton();
-        $methods = $registry->getAllMethods();
+        $methods = $registry->getMethods();
 
         $this->assertCount(1, $methods);
         $this->assertInstanceOf(Method::class, reset($methods));
@@ -31,6 +31,6 @@ class MethodRegistryTest extends SapphireTest
     {
         Config::modify()->set(MethodRegistry::class, 'methods', [Member::class]);
         $registry = MethodRegistry::singleton();
-        $registry->getAllMethods();
+        $registry->getMethods();
     }
 }

--- a/tests/php/Stub/BasicMath/Method.php
+++ b/tests/php/Stub/BasicMath/Method.php
@@ -9,6 +9,16 @@ use SilverStripe\MFA\Method\MethodInterface;
 class Method implements MethodInterface, TestOnly
 {
     /**
+     * Get a URL segment for this method. This will be used in URL paths for performing authentication by this method
+     *
+     * @return string
+     */
+    public function getURLSegment()
+    {
+        return 'basic-math';
+    }
+
+    /**
      * Return the LoginHandler that is used to start and verify login attempts with this method
      *
      * @return LoginHandlerInterface


### PR DESCRIPTION
- The current Members registered MFA methods are provided
- Additional methods that haven't been registered by the user also show up
- The default method will be provided if set
- Fixed an issue where routing was not correct as the base `mfa` endpoint would catch all other routes

This also adds the `MethodRegistry` service to manage methods.

Resolves #6