### PR TITLE
Implement MFA registration API endpoints

### DIFF
--- a/src/Model/RegisteredMethod.php
+++ b/src/Model/RegisteredMethod.php
@@ -61,24 +61,4 @@ class RegisteredMethod extends DataObject
     {
         return $this->getMethod()->getRegisterHandler();
     }
-
-    /**
-     * Accessor for Data field to ensure it's presented as an array instead of a JSON blob
-     *
-     * @return array
-     */
-    public function getData()
-    {
-        return (array) json_decode($this->getField('Data'), true);
-    }
-
-    /**
-     * Setter for the Data field to ensure it's saved as a JSON blob
-     *
-     * @param mixed $data
-     */
-    public function setData($data)
-    {
-        $this->setField('Data', json_encode($data));
-    }
 }

--- a/src/Service/MethodRegistry.php
+++ b/src/Service/MethodRegistry.php
@@ -89,4 +89,21 @@ class MethodRegistry
 
         return $method;
     }
+
+    /**
+     * Fetches a Method by its URL Segment
+     *
+     * @param $segment
+     * @return MethodInterface|null
+     */
+    public function getMethodByURLSegment($segment)
+    {
+        foreach ($this->getMethods() as $method) {
+            if ($method->getURLSegment() === $segment) {
+                return $method;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Service/MethodRegistry.php
+++ b/src/Service/MethodRegistry.php
@@ -93,7 +93,7 @@ class MethodRegistry
     /**
      * Fetches a Method by its URL Segment
      *
-     * @param $segment
+     * @param string $segment
      * @return MethodInterface|null
      */
     public function getMethodByURLSegment($segment)

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -42,7 +42,9 @@ class SessionStore implements StoreInterface
      */
     public function __construct(Member $member = null)
     {
-        $this->member = $member;
+        if (!is_null($member)) {
+            $this->setMember($member);
+        }
     }
 
     /**

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -38,7 +38,15 @@ class SessionStore implements StoreInterface
     protected $state = [];
 
     /**
-     * Create a store from the given request getting any initial state from the session of the request
+     * @param Member $member
+     */
+    public function __construct(Member $member = null)
+    {
+        $this->member = $member;
+    }
+
+    /**
+     * Attempt to create a store from the given request getting any existing state from the session of the request
      *
      * {@inheritdoc}
      */
@@ -46,17 +54,18 @@ class SessionStore implements StoreInterface
     {
         $state = $request->getSession()->get(static::SESSION_KEY);
 
-        $new = new static();
+        if ($state && $state['member']) {
+            /** @var Member $member */
+            $member = DataObject::get_by_id(Member::class, $state['member']);
 
-        if ($state) {
+            $new = new static($member);
             $new->setMethod($state['method']);
             $new->setState($state['state']);
-            if ($state['member']) {
-                $new->setMember(DataObject::get_by_id(Member::class, $state['member']));
-            }
+
+            return $new;
         }
 
-        return $new;
+        return new static();
     }
 
     /**

--- a/src/Store/StoreInterface.php
+++ b/src/Store/StoreInterface.php
@@ -3,6 +3,8 @@
 namespace SilverStripe\MFA\Store;
 
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\MFA\Extension\MemberExtension;
+use SilverStripe\Security\Member;
 
 /**
  * Represents a place for temporarily storing state related to a login or registration attempt.
@@ -16,6 +18,22 @@ interface StoreInterface
      * @return StoreInterface
      */
     public static function create(HTTPRequest $request);
+
+    /**
+     * Persist the stored state for the given request
+     *
+     * @param HTTPRequest $request
+     * @return StoreInterface
+     */
+    public function save(HTTPRequest $request);
+
+    /**
+     * Clear any stored state for the given request
+     *
+     * @param HTTPRequest $request
+     * @return void
+     */
+    public static function clear(HTTPRequest $request);
 
     /**
      * Get the state from the store
@@ -33,18 +51,24 @@ interface StoreInterface
     public function setState(array $state);
 
     /**
-     * Persist the stored state for the given request
-     *
-     * @param HTTPRequest $request
-     * @return StoreInterface
+     * @return Member|MemberExtension
      */
-    public function save(HTTPRequest $request);
+    public function getMember();
 
     /**
-     * Clear any stored state for the given request
-     *
-     * @param HTTPRequest $request
-     * @return void
+     * @param Member $member
+     * @return $this
      */
-    public static function clear(HTTPRequest $request);
+    public function setMember(Member $member);
+
+    /**
+     * @return string
+     */
+    public function getMethod();
+
+    /**
+     * @param string $method
+     * @return $this
+     */
+    public function setMethod($method);
 }

--- a/tests/php/Authenticator/RegisterHandlerTest.php
+++ b/tests/php/Authenticator/RegisterHandlerTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\Authenticator;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\MFA\Authenticator\MemberAuthenticator;
+use SilverStripe\MFA\Extension\MemberExtension;
+use SilverStripe\MFA\Service\MethodRegistry;
+use SilverStripe\MFA\Store\SessionStore;
+use SilverStripe\MFA\Tests\Stub\BasicMath\Method;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
+
+/**
+ * Class RegisterHandlerTest
+ *
+ * @package SilverStripe\MFA\Tests\Authenticator
+ */
+class RegisterHandlerTest extends FunctionalTest
+{
+    const URL = 'Security/login/default/mfa/register/basic-math/';
+
+    protected static $fixture_file = 'RegisterHandlerTest.yml';
+
+    protected function setUp()
+    {
+        parent::setUp();
+        Config::modify()->set(MethodRegistry::class, 'methods', [Method::class]);
+
+        Injector::inst()->load([
+            Security::class => [
+                'properties' => [
+                    'authenticators' => [
+                        'default' => '%$' . MemberAuthenticator::class,
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    /**
+     * Tests that the registration flow can't be started without being logged in (or past basic auth)
+     */
+    public function testRegisterRouteIsPrivateWithGETMethod()
+    {
+        $response = $this->get(self::URL);
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * Tests that the registration flow can't be finished without being logged in (or past basic auth)
+     */
+    public function testRegisterRouteIsPrivateWithPOSTMethod()
+    {
+        $response = $this->post(self::URL, []);
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * Tests that a member can't register a new method during login if they've already registered one before
+     */
+    public function testStartRegistrationFailsWhenInvalidMethodIsPassed()
+    {
+        /** @var Member $freshMember */
+        $freshMember = $this->objFromFixture(Member::class, 'fresh-member');
+
+        $this->scaffoldPartialLogin($freshMember);
+
+        $response = $this->get('Security/login/default/mfa/register/inert/');
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertContains('No such method is available', $response->getBody());
+    }
+
+    /**
+     * Tests that a member can't register a new method during login if they've already registered one before
+     */
+    public function testStartRegistrationFailsWhenRegisteredMethodExists()
+    {
+        /** @var Member $staleMember */
+        $staleMember = $this->objFromFixture(Member::class, 'stale-member');
+
+        $this->scaffoldPartialLogin($staleMember);
+
+        $response = $this->get(self::URL);
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertContains('This member already has an MFA method', $response->getBody());
+    }
+
+    /**
+     * Tests that a member can't register the same method twice
+     */
+    public function testStartRegistrationFailsWhenMethodIsAlreadyRegistered()
+    {
+        $this->logInAs('stale-member');
+
+        $response = $this->get(self::URL);
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertContains('That method has already been registered against this Member', $response->getBody());
+    }
+
+    /**
+     * Assuming the member passed the above checks, tests that the member can get context for registering a method
+     */
+    public function testStartRegistrationSucceeds()
+    {
+        /** @var Member $freshMember */
+        $freshMember = $this->objFromFixture(Member::class, 'fresh-member');
+
+        $this->scaffoldPartialLogin($freshMember);
+
+        $response = $this->get(self::URL);
+        $this->assertEquals(200, $response->getStatusCode(), sprintf('Body: %s', $response->getBody()));
+    }
+
+    /**
+     * Tests that the start registration step must be called before the completion step
+     */
+    public function testFinishRegistrationFailsWhenCalledDirectly()
+    {
+        /** @var Member $freshMember */
+        $freshMember = $this->objFromFixture(Member::class, 'fresh-member');
+
+        $this->scaffoldPartialLogin($freshMember);
+
+        $response = $this->post(self::URL, ['dummy' => 'data'], null, $this->session(), json_encode(['number' => 7]));
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertContains('No registration in progress', $response->getBody());
+    }
+
+    /**
+     * Tests that a nefarious user can't change the method they're registering halfway through
+     */
+    public function testFinishRegistrationFailsWhenMethodIsMismatched()
+    {
+        /** @var Member $freshMember */
+        $freshMember = $this->objFromFixture(Member::class, 'fresh-member');
+
+        $this->scaffoldPartialLogin($freshMember, self::class); // Purposefully set to the wrong class
+
+        $response = $this->post(self::URL, ['dummy' => 'data'], null, $this->session(), json_encode(['number' => 7]));
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertContains('Method does not match registration in progress', $response->getBody());
+    }
+
+    /**
+     * Assuming the member passed the above checks, tests that the member can complete a registration attempt
+     */
+    public function testFinishRegistrationSucceeds()
+    {
+        /** @var Member|MemberExtension $freshMember */
+        $freshMember = $this->objFromFixture(Member::class, 'fresh-member');
+
+        $this->scaffoldPartialLogin($freshMember, 'basic-math');
+
+        $response = $this->post(self::URL, ['dummy' => 'data'], null, $this->session(), json_encode(['number' => 7]));
+        $this->assertEquals(201, $response->getStatusCode(), sprintf('Body: %s', $response->getBody()));
+
+        if ($response->getStatusCode() !== 201) {
+            var_dump($response->getBody());
+        }
+
+        // Make sure the registration made it into the database
+        $registeredMethod = $freshMember->RegisteredMFAMethods()->first();
+        $this->assertNotNull($registeredMethod);
+        $this->assertEquals('{"number":7}', $registeredMethod->Data);
+    }
+
+    /**
+     * Mark the given user as partially logged in - ie. they've entered their email/password and are currently going
+     * through the MFA process
+     *
+     * @param Member $member
+     * @param string $method
+     */
+    protected function scaffoldPartialLogin(Member $member, $method = null)
+    {
+        $this->logOut();
+
+        $this->session()->set(SessionStore::SESSION_KEY, [
+            'member' => $member->ID,
+            'method' => $method,
+            'state' => [],
+        ]);
+    }
+}

--- a/tests/php/Authenticator/RegisterHandlerTest.yml
+++ b/tests/php/Authenticator/RegisterHandlerTest.yml
@@ -1,0 +1,12 @@
+SilverStripe\MFA\Model\RegisteredMethod:
+  math-method-for-stale-user:
+    MethodClassName: 'SilverStripe\MFA\Tests\Stub\BasicMath\Method'
+    Data: '[]'
+
+SilverStripe\Security\Member:
+  fresh-member:
+    Email: 'fresh.member'
+  stale-member:
+    Email: 'stale.member'
+    RegisteredMFAMethods:
+      - =>SilverStripe\MFA\Model\RegisteredMethod.math-method-for-stale-user

--- a/tests/php/Stub/BasicMath/MethodRegisterHandler.php
+++ b/tests/php/Stub/BasicMath/MethodRegisterHandler.php
@@ -5,6 +5,7 @@ namespace SilverStripe\MFA\Tests\Stub\BasicMath;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\MFA\Method\Handler\RegisterHandlerInterface;
+use SilverStripe\MFA\Model\RegisteredMethod;
 use SilverStripe\MFA\Store\StoreInterface;
 
 /**
@@ -21,7 +22,6 @@ class MethodRegisterHandler implements RegisterHandlerInterface, TestOnly
      */
     public function start(StoreInterface $store)
     {
-        // Stub
         return [];
     }
 
@@ -34,7 +34,19 @@ class MethodRegisterHandler implements RegisterHandlerInterface, TestOnly
      */
     public function register(HTTPRequest $request, StoreInterface $store)
     {
-        // Stub
+        $parameters = json_decode($request->getBody(), true);
+
+        if (!array_key_exists('number', $parameters)) {
+            return false;
+        }
+
+        $methodRegistration = RegisteredMethod::create([
+            'MethodClassName' => Method::class,
+            'Data' => json_encode(['number' => $parameters['number']]),
+        ]);
+
+        $store->getMember()->RegisteredMFAMethods()->add($methodRegistration);
+
         return true;
     }
 


### PR DESCRIPTION
This PR fleshes out the `mfa/register` endpoint, covering both GET (startRegistration) and POST (finishRegistration) methods.

It also includes some tweaks to SessionStore, making its behaviour more sensible.