### PR TITLE
Backend implementation for ability to skip MFA registration/login process

### DIFF
--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -268,12 +268,10 @@ class LoginHandler extends BaseLoginHandler
             // Redirect the user back to wherever they originally came from when they started the login process
             return $this->redirectBack();
         } catch (MemberNotFoundException $exception) {
-            if (!$enforcementManager->canSkipMFA($member)) {
-                return $this->jsonResponse(
-                    ['errors' => [_t(__CLASS__ . '.CANNOT_SKIP', 'You cannot skip MFA registration')]],
-                    403
-                );
-            }
+            return $this->jsonResponse(
+                ['errors' => [_t(__CLASS__ . '.CANNOT_SKIP', 'You cannot skip MFA registration')]],
+                403
+            );
         }
     }
 

--- a/src/Exception/MemberNotFoundException.php
+++ b/src/Exception/MemberNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\MFA\Exception;
+
+use Exception;
+
+/**
+ * A member was not found when one was expected to exist
+ */
+class MemberNotFoundException extends Exception
+{
+
+}

--- a/src/Extension/MemberExtension.php
+++ b/src/Extension/MemberExtension.php
@@ -24,7 +24,7 @@ class MemberExtension extends DataExtension
 
     private static $db = [
         'DefaultRegisteredMethodID' => 'Int',
-        'HasSkippedMFARegistration' => 'Bool',
+        'HasSkippedMFARegistration' => 'Boolean',
     ];
 
     /**

--- a/src/Extension/MemberExtension.php
+++ b/src/Extension/MemberExtension.php
@@ -13,6 +13,7 @@ use SilverStripe\Security\Member;
  * @method RegisteredMethod[]|HasManyList RegisteredMFAMethods
  * @property MethodInterface DefaultRegisteredMethod
  * @property string DefaultRegisteredMethodID
+ * @property bool HasSkippedMFARegistration
  * @property Member|MemberExtension owner
  */
 class MemberExtension extends DataExtension
@@ -23,6 +24,7 @@ class MemberExtension extends DataExtension
 
     private static $db = [
         'DefaultRegisteredMethodID' => 'Int',
+        'HasSkippedMFARegistration' => 'Bool',
     ];
 
     /**

--- a/src/Service/EnforcementManager.php
+++ b/src/Service/EnforcementManager.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace SilverStripe\MFA\Service;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\MFA\Extension\MemberExtension;
+use SilverStripe\ORM\FieldType\DBDate;
+use SilverStripe\Security\Member;
+use SilverStripe\SiteConfig\SiteConfig;
+
+/**
+ * The EnforcementManager class is responsible for making decisions regarding multi factor authentication app flow,
+ * e.g. "is MFA required", "should we redirect to the MFA section", "can the user skip MFA registration" etc.
+ */
+class EnforcementManager
+{
+    use Injectable;
+
+    /**
+     * Whether the current member can skip the multi factor authentication registration process.
+     *
+     * This is determined by a combination of:
+     *  - Whether MFA is required or optional
+     *  - If MFA is required, whether there is a grace period
+     *  - If MFA is required and there is a grace period, whether we're currently within that timeframe
+     *
+     * @param Member&MemberExtension $member
+     * @return bool
+     */
+    public function canSkipMFA(Member $member)
+    {
+        if ($this->isMFARequired()) {
+            return false;
+        }
+
+        // If they've already registered MFA methods we will not allow them to skip the authentication process
+        $registeredMethods = $member->RegisteredMFAMethods();
+        if ($registeredMethods->exists()) {
+            return false;
+        }
+
+        // MFA is optional, or is required but might be within a grace period (see isMFARequired)
+        return true;
+    }
+
+    /**
+     * Whether the authentication process should redirect the user to multi factor authentication registration or
+     * login.
+     *
+     * This is determined by a combination of:
+     *  - Whether MFA is required or optional
+     *  - Whether the user has registered MFA methods already
+     *  - If the user doesn't have any registered MFA methods already, and MFA is optional, whether the user has opted
+     *    to skip the registration process
+     *
+     * Note that in determining this, we ignore whether or not MFA is enabled for the site in general.
+     *
+     * @param Member&MemberExtension $member
+     * @return bool
+     */
+    public function shouldRedirectToMFA(Member $member)
+    {
+        $isRequired = $this->isMFARequired();
+        if ($isRequired) {
+            return true;
+        }
+
+        $hasSkipped = $member->HasSkippedMFARegistration;
+        if (!$hasSkipped) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether multi factor authentication is required for site members. This also takes into account whether a
+     * grace period is set and whether we're currently inside the window for it.
+     *
+     * Note that in determining this, we ignore whether or not MFA is enabled for the site in general.
+     *
+     * @return bool
+     */
+    public function isMFARequired()
+    {
+        $siteConfig = SiteConfig::current_site_config();
+
+        $isRequired = $siteConfig->MFARequired;
+        if (!$isRequired) {
+            return false;
+        }
+
+        $gracePeriod = $siteConfig->MFAGracePeriodExpires;
+        if ($isRequired && !$gracePeriod) {
+            return true;
+        }
+
+        /** @var DBDate $gracePeriodDate */
+        $gracePeriodDate = $siteConfig->dbObject('MFAGracePeriodExpires');
+        if ($isRequired && $gracePeriodDate->InPast()) {
+            return true;
+        }
+
+        // MFA is required, a grace period is set, and it's in the future
+        return false;
+    }
+}

--- a/src/Service/MethodRegistry.php
+++ b/src/Service/MethodRegistry.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\MFA\Service;
 
-use LogicException;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
@@ -24,9 +23,9 @@ class MethodRegistry
      * List of configured MFA methods. These should be class names that implement MethodInterface
      *
      * @config
-     * @var array
+     * @var string[]
      */
-    private static $methods;
+    private static $methods = [];
 
     /**
      * Get implementations of all configured methods
@@ -36,7 +35,7 @@ class MethodRegistry
      */
     public function getMethods()
     {
-        $configuredMethods = (array) static::config()->get('methods');
+        $configuredMethods = (array) $this->config()->get('methods');
 
         $allMethods = [];
 

--- a/src/Service/SchemaGenerator.php
+++ b/src/Service/SchemaGenerator.php
@@ -160,7 +160,7 @@ class SchemaGenerator
      *
      * @return bool
      */
-    protected function canSkipMFA()
+    public function canSkipMFA()
     {
         if ($this->isMFARequired()) {
             return false;

--- a/src/Service/SchemaGenerator.php
+++ b/src/Service/SchemaGenerator.php
@@ -222,14 +222,14 @@ class SchemaGenerator
             return false;
         }
 
-        /** @var DBDate $gracePeriod */
-        $gracePeriod = $siteConfig->dbObject('MFAGracePeriodExpires');
-
+        $gracePeriod = $siteConfig->MFAGracePeriodExpires;
         if ($isRequired && !$gracePeriod) {
             return true;
         }
 
-        if ($isRequired && $gracePeriod->InPast()) {
+        /** @var DBDate $gracePeriodDate */
+        $gracePeriodDate = $siteConfig->dbObject('MFAGracePeriodExpires');
+        if ($isRequired && $gracePeriodDate->InPast()) {
             return true;
         }
 

--- a/src/Service/SchemaGenerator.php
+++ b/src/Service/SchemaGenerator.php
@@ -46,51 +46,15 @@ class SchemaGenerator
      */
     public function getSchema()
     {
-        $member = $this->getMember();
+        $registeredMethods = $this->getRegisteredMethods();
 
-        // Get a list of methods registered to the user
-        $registeredMethods = $member->RegisteredMFAMethods();
-
-        // Generate a map of URL Segments to 'lead in labels', which are used to describe the method in the login UI
-        $registeredMethodDetails = [];
-        foreach ($registeredMethods as $registeredMethod) {
-            $method = $registeredMethod->getMethod();
-
-            $registeredMethodDetails[] = [
-                'urlSegment' => $method->getURLSegment(),
-                'leadInLabel' => $method->getLoginHandler()->getLeadInLabel()
-            ];
-        }
-
-        // Prepare an array to hold details for methods available to register
-        $availableMethodDetails = [];
-
-        // Get all methods enabled on the site
-        $allMethods = MethodRegistry::singleton()->getMethods();
-
-        // Compile details for methods that aren't already registered to the user
-        foreach ($allMethods as $method) {
-            // Skip registration details if the user has already registered this method
-            if (in_array($method->getURLSegment(), array_column($registeredMethodDetails, 'urlSegment'))) {
-                continue;
-            }
-
-            $registerHandler = $method->getRegisterHandler();
-
-            $availableMethodDetails[] = [
-                'urlSegment' => $method->getURLSegment(),
-                'name' => $registerHandler->getName(),
-                'description' => $registerHandler->getDescription(),
-                'supportLink' => $registerHandler->getSupportLink(),
-            ];
-        }
-
-        $defaultMethod = $member->DefaultRegisteredMethod;
+        // Skip registration details if the user has already registered this method
+        $exclude = array_column($registeredMethods, 'urlSegment');
 
         $schema = [
-            'registeredMethods' => $registeredMethodDetails,
-            'availableMethods' => $availableMethodDetails,
-            'defaultMethod' => $defaultMethod ? $defaultMethod->getMethod()->getURLSegment() : null,
+            'registeredMethods' => $registeredMethods,
+            'availableMethods' => $this->getAvailableMethods($exclude),
+            'defaultMethod' => $this->getDefaultMethod(),
         ];
 
         $this->extend('updateSchema', $schema);
@@ -112,6 +76,74 @@ class SchemaGenerator
         }
 
         return $member;
+    }
+
+    /**
+     * Get a list of methods registered to the user
+     *
+     * @return array[]
+     */
+    protected function getRegisteredMethods()
+    {
+        $registeredMethods = $this->getMember()->RegisteredMFAMethods();
+
+        // Generate a map of URL Segments to 'lead in labels', which are used to describe the method in the login UI
+        $registeredMethodDetails = [];
+        foreach ($registeredMethods as $registeredMethod) {
+            $method = $registeredMethod->getMethod();
+
+            $registeredMethodDetails[] = [
+                'urlSegment' => $method->getURLSegment(),
+                'leadInLabel' => $method->getLoginHandler()->getLeadInLabel()
+            ];
+        }
+
+        return $registeredMethodDetails;
+    }
+
+    /**
+     * Get details in a list for all available methods, optionally excluding those with urlSegments provided in
+     * $exclude
+     *
+     * @param array $exclude
+     * @return array[]
+     */
+    protected function getAvailableMethods(array $exclude = [])
+    {
+        // Prepare an array to hold details for methods available to register
+        $availableMethods = [];
+
+        // Get all methods enabled on the site
+        $allMethods = MethodRegistry::singleton()->getMethods();
+
+        // Compile details for methods that aren't already registered to the user
+        foreach ($allMethods as $method) {
+            if (in_array($method->getURLSegment(), $exclude)) {
+                continue;
+            }
+
+            $registerHandler = $method->getRegisterHandler();
+
+            $availableMethods[] = [
+                'urlSegment' => $method->getURLSegment(),
+                'name' => $registerHandler->getName(),
+                'description' => $registerHandler->getDescription(),
+                'supportLink' => $registerHandler->getSupportLink(),
+            ];
+        }
+
+        return $availableMethods;
+    }
+
+    /**
+     * Get the URL Segment for the configured default method on the current member, or null if none is configured
+     *
+     * @return string|null
+     */
+    protected function getDefaultMethod()
+    {
+        $defaultMethod = $this->getMember()->DefaultRegisteredMethod;
+        return $defaultMethod ? $defaultMethod->getMethod()->getURLSegment() : null;
     }
 
     /**

--- a/src/Service/SchemaGenerator.php
+++ b/src/Service/SchemaGenerator.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace SilverStripe\MFA\Service;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Extensible;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\MFA\Exception\MemberNotFoundException;
+use SilverStripe\MFA\Extension\MemberExtension;
+use SilverStripe\MFA\Store\StoreInterface;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
+
+/**
+ * Generates a multi-factor authentication frontend app schema from the given request
+ */
+class SchemaGenerator
+{
+    use Extensible;
+    use Injectable;
+
+    /**
+     * @var HTTPRequest
+     */
+    protected $request;
+
+    /**
+     * @var StoreInterface
+     */
+    protected $store;
+
+    /**
+     * @param HTTPRequest $request
+     * @param StoreInterface $store
+     */
+    public function __construct(HTTPRequest $request, StoreInterface $store)
+    {
+        $this->setRequest($request);
+        $this->setStore($store);
+    }
+
+    /**
+     * Gets the schema data for the multi factor authentication app, using the current Member as context
+     *
+     * @return array
+     */
+    public function getSchema()
+    {
+        $member = $this->getMember();
+
+        // Get a list of methods registered to the user
+        $registeredMethods = $member->RegisteredMFAMethods();
+
+        // Generate a map of URL Segments to 'lead in labels', which are used to describe the method in the login UI
+        $registeredMethodDetails = [];
+        foreach ($registeredMethods as $registeredMethod) {
+            $method = $registeredMethod->getMethod();
+
+            $registeredMethodDetails[] = [
+                'urlSegment' => $method->getURLSegment(),
+                'leadInLabel' => $method->getLoginHandler()->getLeadInLabel()
+            ];
+        }
+
+        // Prepare an array to hold details for methods available to register
+        $availableMethodDetails = [];
+
+        // Get all methods enabled on the site
+        $allMethods = MethodRegistry::singleton()->getMethods();
+
+        // Compile details for methods that aren't already registered to the user
+        foreach ($allMethods as $method) {
+            // Skip registration details if the user has already registered this method
+            if (in_array($method->getURLSegment(), array_column($registeredMethodDetails, 'urlSegment'))) {
+                continue;
+            }
+
+            $registerHandler = $method->getRegisterHandler();
+
+            $availableMethodDetails[] = [
+                'urlSegment' => $method->getURLSegment(),
+                'name' => $registerHandler->getName(),
+                'description' => $registerHandler->getDescription(),
+                'supportLink' => $registerHandler->getSupportLink(),
+            ];
+        }
+
+        $defaultMethod = $member->DefaultRegisteredMethod;
+
+        $schema = [
+            'registeredMethods' => $registeredMethodDetails,
+            'availableMethods' => $availableMethodDetails,
+            'defaultMethod' => $defaultMethod ? $defaultMethod->getMethod()->getURLSegment() : null,
+        ];
+
+        $this->extend('updateSchema', $schema);
+
+        return $schema;
+    }
+
+    /**
+     * @return Member|MemberExtension
+     * @throws MemberNotFoundException
+     */
+    public function getMember()
+    {
+        $member = $this->store->getMember() ?: Security::getCurrentUser();
+
+        // If we don't have a valid member we shouldn't be here...
+        if (!$member) {
+            throw new MemberNotFoundException();
+        }
+
+        return $member;
+    }
+
+    /**
+     * @param HTTPRequest $request
+     * @return $this
+     */
+    public function setRequest(HTTPRequest $request)
+    {
+        $this->request = $request;
+        return $this;
+    }
+
+    /**
+     * @param StoreInterface $store
+     * @return $this
+     */
+    public function setStore(StoreInterface $store)
+    {
+        $this->store = $store;
+        return $this;
+    }
+}

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -2,10 +2,13 @@
 
 namespace SilverStripe\MFA\Tests\Authenticator;
 
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\MFA\Authenticator\LoginHandler;
 use SilverStripe\MFA\Authenticator\MemberAuthenticator;
 use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\MFA\Method\MethodInterface;
@@ -207,6 +210,18 @@ class LoginHandlerTest extends FunctionalTest
 
         $member = Member::get()->byID($memberId);
         $this->assertTrue((bool)$member->HasSkippedMFARegistration);
+    }
+
+    /**
+     * @expectedException \SilverStripe\MFA\Exception\MemberNotFoundException
+     */
+    public function testGetMemberThrowsExceptionWithoutMember()
+    {
+        $this->logOut();
+        $handler = new LoginHandler('foo', $this->createMock(MemberAuthenticator::class));
+        $handler->setRequest(new HTTPRequest('GET', '/'));
+        $handler->getRequest()->setSession(new Session([]));
+        $handler->getMember();
     }
 
     /**

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -178,11 +178,7 @@ class LoginHandlerTest extends FunctionalTest
         }
 
         $response = $this->get('Security/login/default/mfa/skip');
-        $result = json_decode($response->getBody(), true);
-
-        $this->assertSame(403, $response->getStatusCode());
-        $this->assertArrayHasKey('errors', $result);
-        $this->assertContains('You cannot skip MFA registration', $result['errors']);
+        $this->assertContains('You cannot skip MFA registration', $response->getBody());
     }
 
     /**

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -42,7 +42,7 @@ class LoginHandlerTest extends FunctionalTest
 
     public function testMFAStepIsAdded()
     {
-        /** @var Member|MemberExtension $member */
+        /** @var Member&MemberExtension $member */
         $member = $this->objFromFixture(Member::class, 'guy');
 
         $this->autoFollowRedirection = false;
@@ -57,7 +57,7 @@ class LoginHandlerTest extends FunctionalTest
     {
         Config::modify()->set(MethodRegistry::class, 'methods', []);
 
-        /** @var Member|MemberExtension $member */
+        /** @var Member&MemberExtension $member */
         $member = $this->objFromFixture(Member::class, 'guy');
 
         // Ensure a URL is set to redirect to after successful login
@@ -84,7 +84,7 @@ class LoginHandlerTest extends FunctionalTest
     public function testMFASchemaEndpointReturnsMethodDetails()
     {
         // "Guy" isn't very security conscious - he has no MFA methods set up
-        /** @var Member|MemberExtension $member */
+        /** @var Member&MemberExtension $member */
         $member = $this->objFromFixture(Member::class, 'guy');
         $this->scaffoldPartialLogin($member);
 
@@ -115,7 +115,7 @@ class LoginHandlerTest extends FunctionalTest
     public function testMFASchemaEndpointShowsRegisteredMethodsIfSetUp()
     {
         // "Simon" is security conscious - he uses the cutting edge MFA methods
-        /** @var Member|MemberExtension $member */
+        /** @var Member&MemberExtension $member */
         $member = $this->objFromFixture(Member::class, 'simon');
         $this->scaffoldPartialLogin($member);
 
@@ -144,7 +144,7 @@ class LoginHandlerTest extends FunctionalTest
     public function testMFASchemaEndpointProvidesDefaultMethodIfSet()
     {
         // "Robbie" is security conscious and is also a CMS expert! He set up MFA and set a default method :o
-        /** @var Member|MemberExtension $member */
+        /** @var Member&MemberExtension $member */
         $member = $this->objFromFixture(Member::class, 'robbie');
         $this->scaffoldPartialLogin($member);
 
@@ -166,14 +166,16 @@ class LoginHandlerTest extends FunctionalTest
 
     /**
      * @param bool $mfaRequired
+     * @param string|null $member
      * @dataProvider cannotSkipMFAProvider
      */
-    public function testCannotSkipMFA($mfaRequired)
+    public function testCannotSkipMFA($mfaRequired, $member = 'robbie')
     {
         $this->setSiteConfig(['MFARequired' => $mfaRequired]);
 
-        /** @var Member|MemberExtension $member */
-        $this->logInAs('robbie');
+        if ($member) {
+            $this->logInAs($member);
+        }
 
         $response = $this->get('Security/login/default/mfa/skip');
         $result = json_decode($response->getBody(), true);
@@ -191,6 +193,7 @@ class LoginHandlerTest extends FunctionalTest
         return [
             'mfa is required' => [false],
             'mfa is not required, but user already has configured methods' => [false],
+            'no member is available' => [false, null],
         ];
     }
 

--- a/tests/php/Service/EnforcementManagerTest.php
+++ b/tests/php/Service/EnforcementManagerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\Service;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\MFA\Extension\MemberExtension;
+use SilverStripe\MFA\Service\EnforcementManager;
+use SilverStripe\MFA\Service\MethodRegistry;
+use SilverStripe\MFA\Tests\Stub\BasicMath\Method as BasicMathMethod;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\Security\Member;
+use SilverStripe\SiteConfig\SiteConfig;
+
+class EnforcementManagerTest extends SapphireTest
+{
+    protected static $fixture_file = 'EnforcementManagerTest.yml';
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        DBDatetime::set_mock_now('2019-01-25 12:00:00');
+
+        $this->setSiteConfig(['MFAEnabled' => true]);
+
+        MethodRegistry::config()->set('methods', [
+            BasicMathMethod::class,
+        ]);
+    }
+
+    public function testCannotSkipWhenMFAIsRequiredWithNoGracePeriod()
+    {
+        $this->setSiteConfig(['MFARequired' => true]);
+
+        $member = new Member();
+        $this->assertFalse(EnforcementManager::create()->canSkipMFA($member));
+    }
+
+    public function testCanSkipWhenMFAIsRequiredWithGracePeriodExpiringInFuture()
+    {
+        $this->setSiteConfig(['MFARequired' => true, 'MFAGracePeriodExpires' => '2019-01-30']);
+
+        $member = new Member();
+        $this->assertTrue(EnforcementManager::create()->canSkipMFA($member));
+    }
+
+    public function testCannotSkipWhenMFAIsRequiredWithGracePeriodExpiringInPast()
+    {
+        $this->setSiteConfig(['MFARequired' => true, 'MFAGracePeriodExpires' => '2018-12-25']);
+
+        $member = new Member();
+        $this->assertFalse(EnforcementManager::create()->canSkipMFA($member));
+    }
+
+    public function testCannotSkipWhenMemberHasRegisteredAuthenticationMethodsSetUp()
+    {
+        $this->setSiteConfig(['MFARequired' => false]);
+        // Sally has "backup codes" as a registered authentication method already
+        /** @var Member $member */
+        $member = $this->objFromFixture(Member::class, 'sally_smith');
+        $this->logInAs($member);
+
+        $this->assertFalse(EnforcementManager::create()->canSkipMFA($member));
+    }
+
+    public function testCanSkipWhenMFAIsOptional()
+    {
+        $this->setSiteConfig(['MFARequired' => false]);
+        // Anonymous admin user
+        $memberId = $this->logInWithPermission();
+        /** @var Member $member */
+        $member = Member::get()->byID($memberId);
+
+        $this->assertTrue(EnforcementManager::create()->canSkipMFA($member));
+    }
+
+    public function testShouldRedirectToMFAWhenMFAIsRequired()
+    {
+        $this->setSiteConfig(['MFARequired' => true]);
+        /** @var Member $member */
+        $member = $this->objFromFixture(Member::class, 'sally_smith');
+        $this->logInAs($member);
+
+        $this->assertTrue(EnforcementManager::create()->shouldRedirectToMFA($member));
+    }
+
+    public function testShouldRedirectToMFAWhenMFAIsOptionalAndHasNotBeenSkipped()
+    {
+        $this->setSiteConfig(['MFARequired' => false]);
+
+        /** @var Member|MemberExtension $member */
+        $member = $this->objFromFixture(Member::class, 'sally_smith');
+        $member->HasSkippedMFARegistration = false;
+        $member->write();
+        $this->logInAs($member);
+
+        $this->assertTrue(EnforcementManager::create()->shouldRedirectToMFA($member));
+    }
+
+    public function testShouldNotRedirectToMFAWhenMFAIsOptionalAndHasBeenSkipped()
+    {
+        $this->setSiteConfig(['MFARequired' => false]);
+
+        /** @var Member&MemberExtension $member */
+        $member = $this->objFromFixture(Member::class, 'sally_smith');
+        $member->HasSkippedMFARegistration = true;
+        $member->write();
+        $this->logInAs($member);
+
+        $this->assertFalse(EnforcementManager::create()->shouldRedirectToMFA($member));
+    }
+
+    /**
+     * Helper method for changing the current SiteConfig values
+     *
+     * @param array $data
+     */
+    protected function setSiteConfig(array $data)
+    {
+        $siteConfig = SiteConfig::current_site_config();
+        $siteConfig->update($data);
+        $siteConfig->write();
+    }
+}

--- a/tests/php/Service/EnforcementManagerTest.yml
+++ b/tests/php/Service/EnforcementManagerTest.yml
@@ -1,0 +1,12 @@
+SilverStripe\MFA\Model\RegisteredMethod:
+  codes:
+    MethodClassName: SilverStripe\MFA\BackupCode\Method
+
+SilverStripe\Security\Member:
+  sally_smith:
+    FirstName: Sally
+    Surname: Smith
+    Email: sally.smith@example.com
+    RegisteredMFAMethods:
+      - =>SilverStripe\MFA\Model\RegisteredMethod.codes
+    DefaultRegisteredMethodID: =>SilverStripe\MFA\Model\RegisteredMethod.codes

--- a/tests/php/Service/SchemaGeneratorTest.php
+++ b/tests/php/Service/SchemaGeneratorTest.php
@@ -164,7 +164,7 @@ class SchemaGeneratorTest extends SapphireTest
      *
      * @param array $data
      */
-    protected function setSiteConfig($data)
+    protected function setSiteConfig(array $data)
     {
         $siteConfig = SiteConfig::current_site_config();
         $siteConfig->update($data);

--- a/tests/php/Service/SchemaGeneratorTest.php
+++ b/tests/php/Service/SchemaGeneratorTest.php
@@ -5,10 +5,14 @@ namespace SilverStripe\MFA\Tests\Service;
 use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\MFA\Service\MethodRegistry;
 use SilverStripe\MFA\Service\SchemaGenerator;
 use SilverStripe\MFA\Store\StoreInterface;
 use SilverStripe\MFA\Tests\Stub\BasicMath\Method as BasicMathMethod;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\Security\Member;
+use SilverStripe\SiteConfig\SiteConfig;
 
 class SchemaGeneratorTest extends SapphireTest
 {
@@ -24,9 +28,18 @@ class SchemaGeneratorTest extends SapphireTest
      */
     protected $store;
 
+    /**
+     * @var SchemaGenerator
+     */
+    protected $generator;
+
     protected function setUp()
     {
         parent::setUp();
+
+        DBDatetime::set_mock_now('2019-01-25 12:00:00');
+
+        $this->setSiteConfig(['MFAEnabled' => true]);
 
         $this->request = $this->createMock(HTTPRequest::class);
         $this->store = $this->createMock(StoreInterface::class);
@@ -34,6 +47,8 @@ class SchemaGeneratorTest extends SapphireTest
         MethodRegistry::config()->set('methods', [
             BasicMathMethod::class,
         ]);
+
+        $this->generator = new SchemaGenerator($this->request, $this->store);
     }
 
     /**
@@ -42,16 +57,14 @@ class SchemaGeneratorTest extends SapphireTest
     public function testGetMemberThrowsExceptionWithoutMember()
     {
         $this->logOut();
-        $generator = new SchemaGenerator($this->request, $this->store);
-        $generator->getMember();
+        $this->generator->getMember();
     }
 
     public function testGetSchema()
     {
         $this->logInAs('sally_smith');
 
-        $generator = new SchemaGenerator($this->request, $this->store);
-        $schema = $generator->getSchema();
+        $schema = $this->generator->getSchema();
 
         $this->assertArrayHasKey('registeredMethods', $schema);
         $this->assertNotEmpty($schema['registeredMethods']);
@@ -63,5 +76,98 @@ class SchemaGeneratorTest extends SapphireTest
         $this->assertSame('backup-codes', $schema['registeredMethods'][0]['urlSegment']);
         $this->assertSame('basic-math', $schema['availableMethods'][0]['urlSegment']);
         $this->assertSame('backup-codes', $schema['defaultMethod']);
+    }
+
+    public function testCannotSkipWhenMFAIsRequiredWithNoGracePeriod()
+    {
+        $this->setSiteConfig(['MFARequired' => true]);
+
+        $schema = $this->generator->getSchema();
+        $this->assertFalse($schema['canSkip']);
+    }
+
+    public function testCanSkipWhenMFAIsRequiredWithGracePeriodExpiringInFuture()
+    {
+        $this->setSiteConfig(['MFARequired' => true, 'MFAGracePeriodExpires' => '2019-01-30']);
+
+        $schema = $this->generator->getSchema();
+        $this->assertTrue($schema['canSkip']);
+    }
+
+    public function testCannotSkipWhenMFAIsRequiredWithGracePeriodExpiringInPast()
+    {
+        $this->setSiteConfig(['MFARequired' => true, 'MFAGracePeriodExpires' => '2018-12-25']);
+
+        $schema = $this->generator->getSchema();
+        $this->assertFalse($schema['canSkip']);
+    }
+
+    public function testCannotSkipWhenMemberHasRegisteredAuthenticationMethodsSetUp()
+    {
+        $this->setSiteConfig(['MFARequired' => false]);
+        // Sally has "backup codes" as a registered authentication method already
+        $this->logInAs('sally_smith');
+
+        $schema = $this->generator->getSchema();
+        $this->assertFalse($schema['canSkip']);
+    }
+
+    public function testCanSkipWhenMFAIsOptional()
+    {
+        $this->setSiteConfig(['MFARequired' => false]);
+        // Anonymous admin user
+        $this->logInWithPermission();
+
+        $schema = $this->generator->getSchema();
+        $this->assertTrue($schema['canSkip']);
+    }
+
+    public function testShouldRedirectToMFAWhenMFAIsRequired()
+    {
+        $this->setSiteConfig(['MFARequired' => true]);
+        $this->logInAs('sally_smith');
+
+        $schema = $this->generator->getSchema();
+        $this->assertTrue($schema['shouldRedirect']);
+    }
+
+    public function testShouldRedirectToMFAWhenMFAIsOptionalAndHasNotBeenSkipped()
+    {
+        $this->setSiteConfig(['MFARequired' => false]);
+
+        /** @var Member|MemberExtension $member */
+        $member = $this->objFromFixture(Member::class, 'sally_smith');
+        $member->HasSkippedMFARegistration = false;
+        $member->write();
+        $this->logInAs($member);
+
+        $schema = $this->generator->getSchema();
+        $this->assertTrue($schema['shouldRedirect']);
+    }
+
+    public function testShouldNotRedirectToMFAWhenMFAIsOptionalAndHasBeenSkipped()
+    {
+        $this->setSiteConfig(['MFARequired' => false]);
+
+        /** @var Member|MemberExtension $member */
+        $member = $this->objFromFixture(Member::class, 'sally_smith');
+        $member->HasSkippedMFARegistration = true;
+        $member->write();
+        $this->logInAs($member);
+
+        $schema = $this->generator->getSchema();
+        $this->assertFalse($schema['shouldRedirect']);
+    }
+
+    /**
+     * Helper method for changing the current SiteConfig values
+     *
+     * @param array $data
+     */
+    protected function setSiteConfig($data)
+    {
+        $siteConfig = SiteConfig::current_site_config();
+        $siteConfig->update($data);
+        $siteConfig->write();
     }
 }

--- a/tests/php/Service/SchemaGeneratorTest.php
+++ b/tests/php/Service/SchemaGeneratorTest.php
@@ -38,13 +38,17 @@ class SchemaGeneratorTest extends SapphireTest
 
         $this->assertArrayHasKey('registeredMethods', $schema);
         $this->assertNotEmpty($schema['registeredMethods']);
+        $this->assertSame('backup-codes', $schema['registeredMethods'][0]['urlSegment']);
+
         $this->assertArrayHasKey('availableMethods', $schema);
         $this->assertNotEmpty($schema['availableMethods']);
+        $this->assertSame('basic-math', $schema['availableMethods'][0]['urlSegment']);
+
         $this->assertArrayHasKey('defaultMethod', $schema);
         $this->assertNotEmpty($schema['defaultMethod']);
-
-        $this->assertSame('backup-codes', $schema['registeredMethods'][0]['urlSegment']);
-        $this->assertSame('basic-math', $schema['availableMethods'][0]['urlSegment']);
         $this->assertSame('backup-codes', $schema['defaultMethod']);
+
+        $this->assertArrayHasKey('canSkip', $schema);
+        $this->assertArrayHasKey('shouldRedirect', $schema);
     }
 }

--- a/tests/php/Service/SchemaGeneratorTest.php
+++ b/tests/php/Service/SchemaGeneratorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\Service;
+
+use PHPUnit_Framework_MockObject_MockObject;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\MFA\Service\MethodRegistry;
+use SilverStripe\MFA\Service\SchemaGenerator;
+use SilverStripe\MFA\Store\StoreInterface;
+use SilverStripe\MFA\Tests\Stub\BasicMath\Method as BasicMathMethod;
+
+class SchemaGeneratorTest extends SapphireTest
+{
+    protected static $fixture_file = 'SchemaGeneratorTest.yml';
+
+    /**
+     * @var HTTPRequest|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $request;
+
+    /**
+     * @var StoreInterface|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $store;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->request = $this->createMock(HTTPRequest::class);
+        $this->store = $this->createMock(StoreInterface::class);
+
+        MethodRegistry::config()->set('methods', [
+            BasicMathMethod::class,
+        ]);
+    }
+
+    /**
+     * @expectedException \SilverStripe\MFA\Exception\MemberNotFoundException
+     */
+    public function testGetMemberThrowsExceptionWithoutMember()
+    {
+        $this->logOut();
+        $generator = new SchemaGenerator($this->request, $this->store);
+        $generator->getMember();
+    }
+
+    public function testGetSchema()
+    {
+        $this->logInAs('sally_smith');
+
+        $generator = new SchemaGenerator($this->request, $this->store);
+        $schema = $generator->getSchema();
+
+        $this->assertArrayHasKey('registeredMethods', $schema);
+        $this->assertNotEmpty($schema['registeredMethods']);
+        $this->assertArrayHasKey('availableMethods', $schema);
+        $this->assertNotEmpty($schema['availableMethods']);
+        $this->assertArrayHasKey('defaultMethod', $schema);
+        $this->assertNotEmpty($schema['defaultMethod']);
+
+        $this->assertSame('backup-codes', $schema['registeredMethods'][0]['urlSegment']);
+        $this->assertSame('basic-math', $schema['availableMethods'][0]['urlSegment']);
+        $this->assertSame('backup-codes', $schema['defaultMethod']);
+    }
+}

--- a/tests/php/Service/SchemaGeneratorTest.php
+++ b/tests/php/Service/SchemaGeneratorTest.php
@@ -2,31 +2,15 @@
 
 namespace SilverStripe\MFA\Tests\Service;
 
-use PHPUnit_Framework_MockObject_MockObject;
-use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\MFA\Service\MethodRegistry;
 use SilverStripe\MFA\Service\SchemaGenerator;
-use SilverStripe\MFA\Store\StoreInterface;
 use SilverStripe\MFA\Tests\Stub\BasicMath\Method as BasicMathMethod;
-use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\Member;
-use SilverStripe\SiteConfig\SiteConfig;
 
 class SchemaGeneratorTest extends SapphireTest
 {
     protected static $fixture_file = 'SchemaGeneratorTest.yml';
-
-    /**
-     * @var HTTPRequest|PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $request;
-
-    /**
-     * @var StoreInterface|PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $store;
 
     /**
      * @var SchemaGenerator
@@ -37,34 +21,20 @@ class SchemaGeneratorTest extends SapphireTest
     {
         parent::setUp();
 
-        DBDatetime::set_mock_now('2019-01-25 12:00:00');
-
-        $this->setSiteConfig(['MFAEnabled' => true]);
-
-        $this->request = $this->createMock(HTTPRequest::class);
-        $this->store = $this->createMock(StoreInterface::class);
-
         MethodRegistry::config()->set('methods', [
             BasicMathMethod::class,
         ]);
 
-        $this->generator = new SchemaGenerator($this->request, $this->store);
-    }
-
-    /**
-     * @expectedException \SilverStripe\MFA\Exception\MemberNotFoundException
-     */
-    public function testGetMemberThrowsExceptionWithoutMember()
-    {
-        $this->logOut();
-        $this->generator->getMember();
+        $this->generator = new SchemaGenerator();
     }
 
     public function testGetSchema()
     {
-        $this->logInAs('sally_smith');
+        /** @var Member $member */
+        $member = $this->objFromFixture(Member::class, 'sally_smith');
+        $this->logInAs($member);
 
-        $schema = $this->generator->getSchema();
+        $schema = $this->generator->getSchema($member);
 
         $this->assertArrayHasKey('registeredMethods', $schema);
         $this->assertNotEmpty($schema['registeredMethods']);
@@ -76,98 +46,5 @@ class SchemaGeneratorTest extends SapphireTest
         $this->assertSame('backup-codes', $schema['registeredMethods'][0]['urlSegment']);
         $this->assertSame('basic-math', $schema['availableMethods'][0]['urlSegment']);
         $this->assertSame('backup-codes', $schema['defaultMethod']);
-    }
-
-    public function testCannotSkipWhenMFAIsRequiredWithNoGracePeriod()
-    {
-        $this->setSiteConfig(['MFARequired' => true]);
-
-        $schema = $this->generator->getSchema();
-        $this->assertFalse($schema['canSkip']);
-    }
-
-    public function testCanSkipWhenMFAIsRequiredWithGracePeriodExpiringInFuture()
-    {
-        $this->setSiteConfig(['MFARequired' => true, 'MFAGracePeriodExpires' => '2019-01-30']);
-
-        $schema = $this->generator->getSchema();
-        $this->assertTrue($schema['canSkip']);
-    }
-
-    public function testCannotSkipWhenMFAIsRequiredWithGracePeriodExpiringInPast()
-    {
-        $this->setSiteConfig(['MFARequired' => true, 'MFAGracePeriodExpires' => '2018-12-25']);
-
-        $schema = $this->generator->getSchema();
-        $this->assertFalse($schema['canSkip']);
-    }
-
-    public function testCannotSkipWhenMemberHasRegisteredAuthenticationMethodsSetUp()
-    {
-        $this->setSiteConfig(['MFARequired' => false]);
-        // Sally has "backup codes" as a registered authentication method already
-        $this->logInAs('sally_smith');
-
-        $schema = $this->generator->getSchema();
-        $this->assertFalse($schema['canSkip']);
-    }
-
-    public function testCanSkipWhenMFAIsOptional()
-    {
-        $this->setSiteConfig(['MFARequired' => false]);
-        // Anonymous admin user
-        $this->logInWithPermission();
-
-        $schema = $this->generator->getSchema();
-        $this->assertTrue($schema['canSkip']);
-    }
-
-    public function testShouldRedirectToMFAWhenMFAIsRequired()
-    {
-        $this->setSiteConfig(['MFARequired' => true]);
-        $this->logInAs('sally_smith');
-
-        $schema = $this->generator->getSchema();
-        $this->assertTrue($schema['shouldRedirect']);
-    }
-
-    public function testShouldRedirectToMFAWhenMFAIsOptionalAndHasNotBeenSkipped()
-    {
-        $this->setSiteConfig(['MFARequired' => false]);
-
-        /** @var Member|MemberExtension $member */
-        $member = $this->objFromFixture(Member::class, 'sally_smith');
-        $member->HasSkippedMFARegistration = false;
-        $member->write();
-        $this->logInAs($member);
-
-        $schema = $this->generator->getSchema();
-        $this->assertTrue($schema['shouldRedirect']);
-    }
-
-    public function testShouldNotRedirectToMFAWhenMFAIsOptionalAndHasBeenSkipped()
-    {
-        $this->setSiteConfig(['MFARequired' => false]);
-
-        /** @var Member|MemberExtension $member */
-        $member = $this->objFromFixture(Member::class, 'sally_smith');
-        $member->HasSkippedMFARegistration = true;
-        $member->write();
-        $this->logInAs($member);
-
-        $schema = $this->generator->getSchema();
-        $this->assertFalse($schema['shouldRedirect']);
-    }
-
-    /**
-     * Helper method for changing the current SiteConfig values
-     *
-     * @param array $data
-     */
-    protected function setSiteConfig(array $data)
-    {
-        $siteConfig = SiteConfig::current_site_config();
-        $siteConfig->update($data);
-        $siteConfig->write();
     }
 }

--- a/tests/php/Service/SchemaGeneratorTest.yml
+++ b/tests/php/Service/SchemaGeneratorTest.yml
@@ -1,0 +1,12 @@
+SilverStripe\MFA\Model\RegisteredMethod:
+  codes:
+    MethodClassName: SilverStripe\MFA\BackupCode\Method
+
+SilverStripe\Security\Member:
+  sally_smith:
+    FirstName: Sally
+    Surname: Smith
+    Email: sally.smith@example.com
+    RegisteredMFAMethods:
+      - =>SilverStripe\MFA\Model\RegisteredMethod.codes
+    DefaultRegisteredMethodID: =>SilverStripe\MFA\Model\RegisteredMethod.codes


### PR DESCRIPTION
* Refactors a little of LoginHandler to move into a SchemaGenerator service
* Adds logic for determining whether the user can skip MFA and whether to redirect to MFA into the schema
* Adds an endpoint to handle processing of the "skip MFA" logic

Resolves #14