### PR TITLE
API Move available and registered method details into encapsulated objects

### DIFF
--- a/_config/state.yml
+++ b/_config/state.yml
@@ -1,0 +1,8 @@
+---
+Name: mfastate
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\MFA\State\AvailableMethodDetailsInterface:
+    class: SilverStripe\MFA\State\AvailableMethodDetails
+  SilverStripe\MFA\State\RegisteredMethodDetailsInterface:
+    class: SilverStripe\MFA\State\RegisteredMethodDetails

--- a/src/BackupCode/Method.php
+++ b/src/BackupCode/Method.php
@@ -6,6 +6,7 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\MFA\Method\Handler\LoginHandlerInterface;
 use SilverStripe\MFA\Method\Handler\RegisterHandlerInterface;
 use SilverStripe\MFA\Method\MethodInterface;
+use SilverStripe\MFA\State\AvailableMethodDetailsInterface;
 
 class Method implements MethodInterface
 {
@@ -55,5 +56,10 @@ class Method implements MethodInterface
     public function getRegisterHandler()
     {
         return Injector::inst()->create(RegisterHandler::class);
+    }
+
+    public function getDetails()
+    {
+        return Injector::inst()->create(AvailableMethodDetailsInterface::class, $this);
     }
 }

--- a/src/Method/MethodInterface.php
+++ b/src/Method/MethodInterface.php
@@ -3,6 +3,7 @@ namespace SilverStripe\MFA\Method;
 
 use SilverStripe\MFA\Method\Handler\LoginHandlerInterface;
 use SilverStripe\MFA\Method\Handler\RegisterHandlerInterface;
+use SilverStripe\MFA\State\AvailableMethodDetailsInterface;
 
 /**
  * Defines an Authentication Method, which serves as an additional factor for authentication beyond the standard
@@ -30,4 +31,9 @@ interface MethodInterface
      * @return RegisterHandlerInterface
      */
     public function getRegisterHandler();
+
+    /**
+     * @return AvailableMethodDetailsInterface
+     */
+    public function getDetails();
 }

--- a/src/Model/RegisteredMethod.php
+++ b/src/Model/RegisteredMethod.php
@@ -5,6 +5,7 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\MFA\Method\Handler\LoginHandlerInterface;
 use SilverStripe\MFA\Method\Handler\RegisterHandlerInterface;
 use SilverStripe\MFA\Method\MethodInterface;
+use SilverStripe\MFA\State\RegisteredMethodDetailsInterface;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
 
@@ -43,7 +44,6 @@ class RegisteredMethod extends DataObject
         if (!$this->method) {
             $this->method = Injector::inst()->create($this->MethodClassName);
         }
-
         return $this->method;
     }
 
@@ -61,5 +61,10 @@ class RegisteredMethod extends DataObject
     public function getRegisterHandler()
     {
         return $this->getMethod()->getRegisterHandler();
+    }
+
+    public function getDetails()
+    {
+        return Injector::inst()->create(RegisteredMethodDetailsInterface::class, $this->getMethod());
     }
 }

--- a/src/State/AvailableMethodDetails.php
+++ b/src/State/AvailableMethodDetails.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SilverStripe\MFA\State;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\MFA\Method\MethodInterface;
+
+class AvailableMethodDetails implements AvailableMethodDetailsInterface
+{
+    use Injectable;
+
+    /**
+     * @var MethodInterface
+     */
+    private $method;
+
+    /**
+     * @param MethodInterface $method
+     */
+    public function __construct(MethodInterface $method)
+    {
+        $this->method = $method;
+    }
+
+    public function getURLSegment()
+    {
+        return $this->method->getURLSegment();
+    }
+
+    public function getName()
+    {
+        return $this->method->getRegisterHandler()->getName();
+    }
+
+    public function getDescription()
+    {
+        return $this->method->getRegisterHandler()->getDescription();
+    }
+
+    public function getSupportLink()
+    {
+        return $this->method->getRegisterHandler()->getSupportLink();
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'urlSegment' => $this->getURLSegment(),
+            'name' => $this->getName(),
+            'description' => $this->getDescription(),
+            'supportLink' => $this->getSupportLink(),
+        ];
+    }
+}

--- a/src/State/AvailableMethodDetailsInterface.php
+++ b/src/State/AvailableMethodDetailsInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SilverStripe\MFA\State;
+
+use JsonSerializable;
+
+/**
+ * Used to provide details about an available {@link \SilverStripe\MFA\Method\MethodInterface} instance, for example
+ * when being used in the multi factor application schema.
+ */
+interface AvailableMethodDetailsInterface extends JsonSerializable
+{
+    /**
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * @return string
+     */
+    public function getURLSegment();
+
+    /**
+     * @return string
+     */
+    public function getDescription();
+
+    /**
+     * @return string
+     */
+    public function getSupportLink();
+}

--- a/src/State/RegisteredMethodDetails.php
+++ b/src/State/RegisteredMethodDetails.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SilverStripe\MFA\State;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\MFA\Method\MethodInterface;
+
+class RegisteredMethodDetails implements RegisteredMethodDetailsInterface
+{
+    use Injectable;
+
+    /**
+     * @var MethodInterface
+     */
+    private $method;
+
+    /**
+     * @param MethodInterface $Method
+     */
+    public function __construct(MethodInterface $method)
+    {
+        $this->method = $method;
+    }
+
+    public function getURLSegment()
+    {
+        return $this->method->getURLSegment();
+    }
+
+    public function getLeadInLabel()
+    {
+        return $this->method->getLoginHandler()->getLeadInLabel();
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'urlSegment' => $this->getURLSegment(),
+            'leadInLabel' => $this->getLeadInLabel(),
+        ];
+    }
+}

--- a/src/State/RegisteredMethodDetailsInterface.php
+++ b/src/State/RegisteredMethodDetailsInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SilverStripe\MFA\State;
+
+use JsonSerializable;
+
+/**
+ * Used to provide details about a registered {@link \SilverStripe\MFA\Method\MethodInterface} instance, for example
+ * when being used in the multi factor application schema.
+ */
+interface RegisteredMethodDetailsInterface extends JsonSerializable
+{
+    /**
+     * @return string
+     */
+    public function getURLSegment();
+
+    /**
+     * @return string
+     */
+    public function getLeadInLabel();
+}

--- a/tests/php/Service/SchemaGeneratorTest.php
+++ b/tests/php/Service/SchemaGeneratorTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\MFA\Tests\Service;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\MFA\Service\MethodRegistry;
 use SilverStripe\MFA\Service\SchemaGenerator;
+use SilverStripe\MFA\State\RegisteredMethodDetailsInterface;
 use SilverStripe\MFA\Tests\Stub\BasicMath\Method as BasicMathMethod;
 use SilverStripe\Security\Member;
 
@@ -37,12 +38,12 @@ class SchemaGeneratorTest extends SapphireTest
         $schema = $this->generator->getSchema($member);
 
         $this->assertArrayHasKey('registeredMethods', $schema);
-        $this->assertNotEmpty($schema['registeredMethods']);
-        $this->assertSame('backup-codes', $schema['registeredMethods'][0]['urlSegment']);
+        $this->assertContainsOnlyInstancesOf(RegisteredMethodDetailsInterface::class, $schema['registeredMethods']);
+        $this->assertSame('backup-codes', $schema['registeredMethods'][0]->getURLSegment());
 
         $this->assertArrayHasKey('availableMethods', $schema);
-        $this->assertNotEmpty($schema['availableMethods']);
-        $this->assertSame('basic-math', $schema['availableMethods'][0]['urlSegment']);
+        $this->assertContainsOnlyInstancesOf(RegisteredMethodDetailsInterface::class, $schema['registeredMethods']);
+        $this->assertSame('basic-math', $schema['availableMethods'][0]->getURLSegment());
 
         $this->assertArrayHasKey('defaultMethod', $schema);
         $this->assertNotEmpty($schema['defaultMethod']);

--- a/tests/php/State/AvailableMethodDetailsTest.php
+++ b/tests/php/State/AvailableMethodDetailsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\State;
+
+use PHPUnit_Framework_MockObject_MockObject;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\MFA\Method\Handler\RegisterHandlerInterface;
+use SilverStripe\MFA\Method\MethodInterface;
+use SilverStripe\MFA\State\AvailableMethodDetails;
+
+class AvailableMethodDetailsTest extends SapphireTest
+{
+    /**
+     * @var MethodInterface|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $method;
+
+    /**
+     * @var AvailableMethodDetails
+     */
+    protected $details;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->method = $this->createMock(MethodInterface::class);
+        $this->method->method('getRegisterHandler')->willReturn(
+            $this->createMock(RegisterHandlerInterface::class)
+        );
+
+        $this->details = new AvailableMethodDetails($this->method);
+    }
+
+    public function testGetDescription()
+    {
+        $this->method->getRegisterHandler()->expects($this->once())->method('getDescription')->willReturn('foo');
+        $this->assertSame('foo', $this->details->getDescription());
+    }
+
+    public function testGetName()
+    {
+        $this->method->getRegisterHandler()->expects($this->once())->method('getName')->willReturn('Backup Codes');
+        $this->assertSame('Backup Codes', $this->details->getName());
+    }
+
+    public function testJsonSerialize()
+    {
+        $this->method->getRegisterHandler()->expects($this->once())->method('getName')->willReturn('Backup Codes');
+        $result = json_encode($this->details);
+        $this->assertContains('Backup Codes', $result);
+    }
+
+    public function testGetSupportLink()
+    {
+        $this->method->getRegisterHandler()->expects($this->once())->method('getSupportLink')->willReturn('google.com');
+        $this->assertSame('google.com', $this->details->getSupportLink());
+    }
+
+    public function testGetURLSegment()
+    {
+        $this->method->expects($this->once())->method('getURLSegment')->willReturn('backup-codes');
+        $this->assertSame('backup-codes', $this->details->getURLSegment());
+    }
+}

--- a/tests/php/State/RegisteredMethodDetailsTest.php
+++ b/tests/php/State/RegisteredMethodDetailsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\State;
+
+use PHPUnit_Framework_MockObject_MockObject;
+use SilverStripe\MFA\Method\Handler\LoginHandlerInterface;
+use SilverStripe\MFA\Method\MethodInterface;
+use SilverStripe\MFA\State\RegisteredMethodDetails;
+
+class RegisteredMethodDetailsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MethodInterface|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $method;
+
+    /**
+     * @var RegisteredMethodDetails
+     */
+    protected $details;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->method = $this->createMock(MethodInterface::class);
+        $this->method->method('getLoginHandler')->willReturn(
+            $this->createMock(LoginHandlerInterface::class)
+        );
+
+        $this->details = new RegisteredMethodDetails($this->method);
+    }
+
+    public function testJsonSerialize()
+    {
+        $this->method->expects($this->once())->method('getURLSegment')->willReturn('foo-bar');
+        $result = json_encode($this->details);
+        $this->assertContains('foo-bar', $result);
+    }
+
+    public function testGetURLSegment()
+    {
+        $this->method->expects($this->once())->method('getURLSegment')->willReturn('foo-bar');
+        $this->assertSame('foo-bar', $this->details->getURLSegment());
+    }
+
+    public function testGetLeadInLabel()
+    {
+        $this->method->getLoginHandler()->expects($this->once())->method('getLeadInLabel')->willReturn('Hello');
+        $this->assertSame('Hello', $this->details->getLeadInLabel());
+    }
+}

--- a/tests/php/Stub/BasicMath/Method.php
+++ b/tests/php/Stub/BasicMath/Method.php
@@ -5,6 +5,7 @@ use SilverStripe\Dev\TestOnly;
 use SilverStripe\MFA\Method\Handler\LoginHandlerInterface;
 use SilverStripe\MFA\Method\Handler\RegisterHandlerInterface;
 use SilverStripe\MFA\Method\MethodInterface;
+use SilverStripe\MFA\State\AvailableMethodDetails;
 
 class Method implements MethodInterface, TestOnly
 {
@@ -36,5 +37,10 @@ class Method implements MethodInterface, TestOnly
     public function getRegisterHandler()
     {
         return new MethodRegisterHandler();
+    }
+
+    public function getDetails()
+    {
+        return new AvailableMethodDetails($this);
     }
 }


### PR DESCRIPTION
Using some state encapsulation interfaces instead of arrays in schema generation process