### PR TITLE
FIX Update wording on back-up codes

### DIFF
--- a/src/BackupCode/LoginHandler.php
+++ b/src/BackupCode/LoginHandler.php
@@ -73,7 +73,7 @@ class LoginHandler implements LoginHandlerInterface
      */
     public function getLeadInLabel()
     {
-        return _t(__CLASS__ . '.LEAD_IN', 'Enter one of your recovery codes');
+        return _t(__CLASS__ . '.LEAD_IN', 'Verify with recovery code');
     }
 
     /**


### PR DESCRIPTION
Minor tweak to the "lead-in" text on logging in with back-up codes as discussed with @newleeland .