### PR TITLE
API StoreInterface is now injectable. Removed ::create() in favour of constructor.

### DIFF
--- a/_config/store.yml
+++ b/_config/store.yml
@@ -1,0 +1,6 @@
+---
+Name: mfastore
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\MFA\Store\StoreInterface:
+    class: SilverStripe\MFA\Store\SessionStore

--- a/readme.md
+++ b/readme.md
@@ -29,8 +29,38 @@ After installing this module _and_ a supported factor method module (e.g. TOTP),
 will be replaced with the MFA authenticator instead. This will provide no change in the steps taken to log in until
 an MFA Method has also been configured for the site:
 
-```yml
+```yaml
 SilverStripe\MFA\Service\MethodRegistry:
   methods:
     # register methods here
 ```
+
+## Configuring encryption providers
+
+By default this module uses defuse/php-encryption as its encryption adapter. You can add your own implementation if
+you would like to use something different, by implementing `EncryptionAdapterInterface` and configuring your service
+class with Injector. The interface is deliberately simple, and takes `encrypt()` and `decrypt()` methods with a
+payload and an encryption key argument.
+
+```yaml
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\MFA\Service\EncryptionAdapterInterface:
+    class: App\MFA\ReallyStrongEncryptionAdapter
+
+```
+
+## Data store interfaces
+
+Since the MFA architecture is largely designed to be decoupled, we use a `StoreInterface` implementation to retain
+data between requests. The default implementation for this interface is `SessionStore` which stores data in PHP
+sessions. If you need to use a different storage mechanism (e.g. Redis, DynamoDB etc) you can implement and configure
+your own `StoreInterface`, and register it with Injector:
+
+```yaml
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\MFA\Store\StoreInterface:
+    class: App\MFA\RedisStoreInterface
+```
+
+Please note that the store should always be treated as a server side implementation. It's not a good idea to implement
+a client store e.g. cookies.

--- a/src/Store/StoreInterface.php
+++ b/src/Store/StoreInterface.php
@@ -16,7 +16,7 @@ interface StoreInterface
      *
      * @param HTTPRequest|null $request
      */
-    public function __construct(HTTPRequest $request = null);
+    public function __construct(?HTTPRequest $request = null);
 
     /**
      * Persist the stored state for the given request

--- a/src/Store/StoreInterface.php
+++ b/src/Store/StoreInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace SilverStripe\MFA\Store;
 
@@ -12,20 +12,12 @@ use SilverStripe\Security\Member;
 interface StoreInterface
 {
     /**
-     * Create a store from the given request, using any initial state related to the request that has been persisted
-     *
-     * @param HTTPRequest $request
-     * @return StoreInterface
-     */
-    public static function create(HTTPRequest $request);
-
-    /**
      * Persist the stored state for the given request
      *
      * @param HTTPRequest $request
      * @return StoreInterface
      */
-    public function save(HTTPRequest $request);
+    public function save(HTTPRequest $request): StoreInterface;
 
     /**
      * Clear any stored state for the given request
@@ -33,14 +25,14 @@ interface StoreInterface
      * @param HTTPRequest $request
      * @return void
      */
-    public static function clear(HTTPRequest $request);
+    public static function clear(HTTPRequest $request): void;
 
     /**
      * Get the state from the store
      *
      * @return array
      */
-    public function getState();
+    public function getState(): array;
 
     /**
      * Update the state in the store
@@ -48,27 +40,27 @@ interface StoreInterface
      * @param array $state
      * @return StoreInterface
      */
-    public function setState(array $state);
+    public function setState(array $state): StoreInterface;
 
     /**
-     * @return Member|MemberExtension
+     * @return Member&MemberExtension|null
      */
-    public function getMember();
+    public function getMember(): ?Member;
 
     /**
      * @param Member $member
      * @return $this
      */
-    public function setMember(Member $member);
+    public function setMember(Member $member): StoreInterface;
 
     /**
      * @return string
      */
-    public function getMethod();
+    public function getMethod(): ?string;
 
     /**
      * @param string $method
      * @return $this
      */
-    public function setMethod($method);
+    public function setMethod($method): StoreInterface;
 }

--- a/src/Store/StoreInterface.php
+++ b/src/Store/StoreInterface.php
@@ -12,6 +12,13 @@ use SilverStripe\Security\Member;
 interface StoreInterface
 {
     /**
+     * Create a new StoreInterface, optionally given an HTTPRequest object
+     *
+     * @param HTTPRequest|null $request
+     */
+    public function __construct(HTTPRequest $request = null);
+
+    /**
      * Persist the stored state for the given request
      *
      * @param HTTPRequest $request


### PR DESCRIPTION
create() and __construct() seem to be doing the same thing. This adjusts so that
__construct() is used instead, and the service is defined in config and handled
by Injector. Updated docs to reflect this change.