### PR TITLE
API Backup code generation has been moved into a BackupCodeGeneratorInterface service

### DIFF
--- a/_config/backupcodes.yml
+++ b/_config/backupcodes.yml
@@ -4,3 +4,7 @@ name: MFABackupCodeAuthenticator
 SilverStripe\MFA\Service\MethodRegistry:
   methods:
     backupCodes: SilverStripe\MFA\BackupCode\Method
+
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\MFA\Service\BackupCodeGeneratorInterface:
+    class: SilverStripe\MFA\Service\BackupCodeGenerator

--- a/src/BackupCode/Method.php
+++ b/src/BackupCode/Method.php
@@ -11,24 +11,6 @@ use SilverStripe\MFA\Method\MethodInterface;
 class Method implements MethodInterface
 {
     /**
-     * The number of back-up codes that should be generated for a user. Note that changing this value will not
-     * regenerate or generate new codes to meet the new number. The user will have to manually regenerate codes to
-     * receive the new number of codes.
-     *
-     * @config
-     * @var int
-     */
-    private static $backup_code_count = 9;
-
-    /**
-     * The length of each individual backup code
-     *
-     * @config
-     * @var int
-     */
-    private static $backup_code_length = 6;
-
-    /**
      * Get a URL segment for this method. This will be used in URL paths for performing authentication by this method
      *
      * @return string

--- a/src/Service/BackupCodeGenerator.php
+++ b/src/Service/BackupCodeGenerator.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\MFA\Service;
+
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Extensible;
+use SilverStripe\Core\Injector\Injectable;
+
+class BackupCodeGenerator implements BackupCodeGeneratorInterface
+{
+    use Configurable;
+    use Extensible;
+    use Injectable;
+
+    /**
+     * The number of back-up codes that should be generated for a user. Note that changing this value will not
+     * regenerate or generate new codes to meet the new number. The user will have to manually regenerate codes to
+     * receive the new number of codes.
+     *
+     * @config
+     * @var int
+     */
+    private static $backup_code_count = 15;
+
+    /**
+     * The length of each individual backup code.
+     *
+     * @config
+     * @var int
+     */
+    private static $backup_code_length = 9;
+
+    /**
+     * Generates a list of backup codes
+     *
+     * {@inheritDoc}
+     */
+    public function generate(): array
+    {
+        $codeCount = (int) $this->config()->get('backup_code_count');
+        $codeLength = (int) $this->config()->get('backup_code_length');
+        $charset = $this->getCharacterSet();
+
+        $codes = [];
+        while (count($codes) < $codeCount) {
+            $code = $this->generateCode($charset, $codeLength);
+            if (!in_array($code, $codes)) {
+                $codes[] = $code;
+            }
+        }
+
+        // Create hashes for the codes
+        $hashedCodes = array_map([$this, 'hash'], $codes);
+
+        return array_combine($codes, $hashedCodes);
+    }
+
+    /**
+     * Hash a back-up code for storage. This uses the native PHP password_hash API by default, but can be extended to
+     * implement a custom hash requirement callback.
+     *
+     * {@inheritDoc}
+     */
+    public function hash(string $code): string
+    {
+        $hash = (string) password_hash($code, PASSWORD_DEFAULT);
+
+        $this->extend('updateHash', $code, $hash);
+
+        return $hash;
+    }
+
+    public function getCharacterSet(): array
+    {
+        $characterSet = array_merge(
+            range('a', 'z'),
+            range('A', 'Z'),
+            range(0, 9)
+        );
+
+        $this->extend('updateCharacterSet', $characterSet);
+
+        return $characterSet;
+    }
+
+    /**
+     * Generates a backup code at the specified string length, using a mixture of digits and mixed case letters
+     *
+     * @param array $charset
+     * @param int $codeLength
+     * @return string
+     */
+    protected function generateCode(array $charset, int $codeLength = 9): string
+    {
+        $characters = [];
+        $numberOfOptions = count($charset);
+        while (count($characters) < $codeLength) {
+            $key = random_int(0, $numberOfOptions - 1); // zero based array
+            $characters[] = $charset[$key];
+        }
+        return implode($characters);
+    }
+}

--- a/src/Service/BackupCodeGeneratorInterface.php
+++ b/src/Service/BackupCodeGeneratorInterface.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\MFA\Service;
+
+/**
+ * A service class implementation for generating and hashing backup codes.
+ */
+interface BackupCodeGeneratorInterface
+{
+    /**
+     * Generate a list of backup codes and return them in a key -> value pair of plain text to hashed values.
+     *
+     * @return string[] Key value pairs of plaintext and hashes
+     */
+    public function generate(): array;
+
+    /**
+     * Hash the given backup code for storage.
+     *
+     * @param string $code
+     * @return string
+     */
+    public function hash(string $code): string;
+
+    /**
+     * Returns a list of possible characters to use in backup codes.
+     *
+     * @return array
+     */
+    public function getCharacterSet(): array;
+}

--- a/tests/php/BackupCode/RegisterHandlerTest.php
+++ b/tests/php/BackupCode/RegisterHandlerTest.php
@@ -4,7 +4,6 @@ namespace SilverStripe\MFA\Tests\BackupCode;
 
 use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Control\HTTPRequest;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\MFA\BackupCode\Method;
 use SilverStripe\MFA\BackupCode\RegisterHandler;
@@ -30,32 +29,6 @@ class RegisterHandlerTest extends SapphireTest
 
         $this->assertArrayHasKey('codes', $props, 'Codes are returned from the start method');
         $this->assertGreaterThan(0, count($props['codes']), 'At least one code is provided');
-        $this->assertTrue(is_numeric(reset($props['codes'])), 'Codes produced are numeric');
-    }
-
-    public function testStartGeneratesCodesMatchingConfig()
-    {
-        Config::modify()->set(Method::class, 'backup_code_count', 5);
-        Config::modify()->set(Method::class, 'backup_code_length', 12); // Exceeds PHP_INT_MAX on 32 bit
-
-        /** @var StoreInterface|PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->createMock(StoreInterface::class);
-        $store->expects($this->once())->method('getMember')->willReturn(Security::getCurrentUser());
-
-        $handler = new RegisterHandler();
-
-        $props = $handler->start($store);
-
-        $this->assertArrayHasKey('codes', $props, 'Codes are returned from the start method');
-
-        $codes = $props['codes'];
-
-        $this->assertCount(5, $codes, 'Only 5 codes are generated as configured');
-
-        foreach ($codes as $code) {
-            $this->assertSame(12, strlen($code), 'Codes are 12 characters long as configured');
-            $this->assertTrue(is_numeric($code), 'Codes generated are numeric');
-        }
     }
 
     public function testStartStoresHashesOfBackupCodesOnMember()

--- a/tests/php/Service/BackupCodeGeneratorTest.php
+++ b/tests/php/Service/BackupCodeGeneratorTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\MFA\Service;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\MFA\Tests\Service\BackupCodeGeneratorTest\MockHashExtension;
+
+class BackupCodeGeneratorTest extends SapphireTest
+{
+    protected static $required_extensions = [
+        BackupCodeGenerator::class => [
+            MockHashExtension::class,
+        ],
+    ];
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        BackupCodeGenerator::config()
+            ->set('backup_code_count', 3)
+            ->set('backup_code_length', 6);
+    }
+
+    public function testHash()
+    {
+        $generator = new BackupCodeGenerator();
+        $result = $generator->hash('hello world');
+        $this->assertSame('dlrow olleh', $result);
+    }
+
+    public function testGenerate()
+    {
+        $generator = new BackupCodeGenerator();
+        $result = $generator->generate();
+
+        $this->assertCount(3, $result, 'Expected number of codes are generated');
+        foreach ($result as $code => $hash) {
+            $this->assertSame(6, strlen($code), 'Generated codes are of configured length');
+            $this->assertSame(strrev($code), $hash, 'Mock hashing method is used and hash is returned');
+        }
+    }
+}

--- a/tests/php/Service/BackupCodeGeneratorTest/MockHashExtension.php
+++ b/tests/php/Service/BackupCodeGeneratorTest/MockHashExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\Service\BackupCodeGeneratorTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class MockHashExtension extends Extension implements TestOnly
+{
+    /**
+     * Mock the hashing process by returning the reversed input
+     *
+     * @param string $code
+     * @param string $hash
+     */
+    public function updateHash($code, &$hash)
+    {
+        $hash = strrev($code);
+    }
+}


### PR DESCRIPTION
The default length is now 9 characters (alphanumeric, mixed case) and the default number generated is now 15 instead of 9.

Resolves https://github.com/silverstripe/silverstripe-mfa/issues/71