### PR TITLE
API BackupCodeGenerator::hash() now throws a HashFailedException when the result hash is the same as the plain text input

### DIFF
--- a/src/Exception/HashFailedException.php
+++ b/src/Exception/HashFailedException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\MFA\Exception;
+
+use RuntimeException;
+
+/**
+ * Represents a failure to correctly hash a multi factory authentication code
+ */
+class HashFailedException extends RuntimeException
+{
+
+}

--- a/src/Service/BackupCodeGenerator.php
+++ b/src/Service/BackupCodeGenerator.php
@@ -5,6 +5,7 @@ namespace SilverStripe\MFA\Service;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\MFA\Exception\HashFailedException;
 
 class BackupCodeGenerator implements BackupCodeGeneratorInterface
 {
@@ -66,6 +67,10 @@ class BackupCodeGenerator implements BackupCodeGeneratorInterface
         $hash = (string) password_hash($code, PASSWORD_DEFAULT);
 
         $this->extend('updateHash', $code, $hash);
+
+        if ($hash === $code) {
+            throw new HashFailedException('Hash must not equal the plaintext code!');
+        }
 
         return $hash;
     }

--- a/src/Service/BackupCodeGeneratorInterface.php
+++ b/src/Service/BackupCodeGeneratorInterface.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\MFA\Service;
 
+use SilverStripe\MFA\Exception\HashFailedException;
+
 /**
  * A service class implementation for generating and hashing backup codes.
  */
@@ -15,10 +17,12 @@ interface BackupCodeGeneratorInterface
     public function generate(): array;
 
     /**
-     * Hash the given backup code for storage.
+     * Hash the given backup code for storage. May throw an exception if hashing fails, or if the hash
+     * is the same as the input plaintext code.
      *
      * @param string $code
      * @return string
+     * @throws HashFailedException
      */
     public function hash(string $code): string;
 

--- a/tests/php/Service/BackupCodeGeneratorTest.php
+++ b/tests/php/Service/BackupCodeGeneratorTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\MFA\Service;
 
+use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\MFA\Tests\Service\BackupCodeGeneratorTest\MockHashExtension;
 
@@ -27,6 +28,26 @@ class BackupCodeGeneratorTest extends SapphireTest
         $generator = new BackupCodeGenerator();
         $result = $generator->hash('hello world');
         $this->assertSame('dlrow olleh', $result);
+    }
+
+    /**
+     * @expectedException \SilverStripe\MFA\Exception\HashFailedException
+     * @expectedExceptionMessage Hash must not equal the plaintext code!
+     */
+    public function testHashThrowsException()
+    {
+        /** @var BackupCodeGenerator|PHPUnit_Framework_MockObject_MockObject $generatorMock */
+        $generatorMock = $this->getMockBuilder(BackupCodeGenerator::class)
+            ->setMethods(['extend'])
+            ->getMock();
+
+        $generatorMock->expects($this->once())->method('extend')->with('updateHash')
+            // Somebody has defined an extension which sets the hash as the plain text value
+            ->willReturnCallback(function ($name, $code, &$hash) {
+                $hash = $code;
+            });
+
+        $generatorMock->hash('ABC123');
     }
 
     public function testGenerate()


### PR DESCRIPTION
To ensure people don't do this in their projects. We discussed implementing something similar for hashing configuration to ensure a minimum amount of entropy, but decided that would be opinionated. If the hash and plaintext is the same it is not opinionated to say this is bad, however.