### PR TITLE
API Moving verification logic to a trait for easier re-usability

### DIFF
--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -570,7 +570,7 @@ class LoginHandler extends BaseLoginHandler
             // These next two lines are pulled from "parent::doLogin()"
             $this->performLogin($member, $data, $request);
             // Allow operations on the member after successful login
-            $this->extend('afterLogin', $member);
+            parent::extend('afterLogin', $member);
         }
     }
 }

--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -99,6 +99,8 @@ class LoginHandler extends BaseLoginHandler
         /** @var StoreInterface $store */
         $store = Injector::inst()->create(StoreInterface::class, $member);
         $store->save($request);
+        // Ensure use of the getter returns the new store
+        $this->store = $store;
 
         // Store the BackURL for use after the process is complete
         if (!empty($data)) {

--- a/src/Exception/InvalidMethodException.php
+++ b/src/Exception/InvalidMethodException.php
@@ -1,0 +1,9 @@
+<?php
+namespace SilverStripe\MFA\Exception;
+
+use LogicException;
+
+class InvalidMethodException extends LogicException
+{
+
+}

--- a/src/RequestHandler/LoginHandlerTrait.php
+++ b/src/RequestHandler/LoginHandlerTrait.php
@@ -127,7 +127,7 @@ trait LoginHandlerTrait
      * @param StoreInterface $store
      * @return bool
      */
-    protected function isLoginComplete(StoreInterface $store)
+    protected function isLoginComplete(StoreInterface $store): bool
     {
         // Pull the successful methods from session
         $successfulMethods = $store->getVerifiedMethods();
@@ -144,9 +144,10 @@ trait LoginHandlerTrait
      * Respond with the given array as a JSON response
      *
      * @param array $response
+     * @param int $code The HTTP response code to set on the response
      * @return HTTPResponse
      */
-    protected function jsonResponse(array $response, $code = 200)
+    protected function jsonResponse(array $response, int $code = 200): HTTPResponse
     {
         return HTTPResponse::create(json_encode($response))
             ->addHeader('Content-Type', 'application/json')

--- a/src/RequestHandler/LoginHandlerTrait.php
+++ b/src/RequestHandler/LoginHandlerTrait.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace SilverStripe\MFA\RequestHandler;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\MFA\Exception\InvalidMethodException;
+use SilverStripe\MFA\Method\MethodInterface;
+use SilverStripe\MFA\Service\EnforcementManager;
+use SilverStripe\MFA\Service\MethodRegistry;
+use SilverStripe\MFA\Service\RegisteredMethodManager;
+use SilverStripe\MFA\Store\StoreInterface;
+
+/**
+ * This trait encapsulates logic that can be added to a `RequestHandler` to work with logging in using MFA front-end
+ * app. It provides two main methods; @see createStartLoginResponse - a response that can be easily consumed by the MFA
+ * app to prompt a login, and @see verifyLoginRequest - used to verify a request sent by the MFA app containing the
+ * login attempt.
+ */
+trait LoginHandlerTrait
+{
+    /**
+     * @return MethodRegistry
+     */
+    protected function getMethodRegistry(): MethodRegistry
+    {
+        return MethodRegistry::singleton();
+    }
+
+    /**
+     * @return RegisteredMethodManager
+     */
+    protected function getRegisteredMethodManager(): RegisteredMethodManager
+    {
+        return RegisteredMethodManager::singleton();
+    }
+
+    /**
+     * Create an HTTPResponse that provides information to the client side React MFA app to prompt the user to login
+     * with their configured MFA method
+     *
+     * @param StoreInterface $store
+     * @param MethodInterface|null $requestedMethod
+     * @return HTTPResponse
+     */
+    protected function createStartLoginResponse(
+        StoreInterface $store,
+        ?MethodInterface $requestedMethod = null
+    ): HTTPResponse {
+        $registeredMethod = null;
+        $member = $store->getMember();
+
+        // Use a requested method if provided
+        if ($requestedMethod) {
+            $registeredMethod = $this->getRegisteredMethodManager()->getFromMember($member, $requestedMethod);
+        }
+
+        // ...Or use the default (TODO: Should we have the default as a fallback? Maybe just if no method is specified?)
+        if (!$registeredMethod) {
+            $registeredMethod = $member->DefaultRegisteredMethod;
+        }
+
+        // We can't proceed with login if the Member doesn't have this method registered
+        if (!$registeredMethod) {
+            // We can display a specific message if there was no method specified
+            if (!$requestedMethod) {
+                $message = _t(
+                    __CLASS__ . '.METHOD_NOT_PROVIDED',
+                    'No method was provided to login with and the Member has no default'
+                );
+            } else {
+                $message = _t(__CLASS__ . '.METHOD_NOT_REGISTERED', 'Member does not have this method registered');
+            }
+
+            return $this->jsonResponse(
+                ['errors' => [$message]],
+                400
+            );
+        }
+
+        // Mark the given method as started within the store
+        $store->setMethod($registeredMethod->getMethod()->getURLSegment());
+        // Allow the authenticator to begin the process and generate some data to pass through to the front end
+        $data = $registeredMethod->getLoginHandler()->start($store, $registeredMethod);
+
+        // Respond with our method
+        return $this->jsonResponse($data ?: []);
+    }
+
+    /**
+     * Attempt to verify a login attempt provided by the given request
+     *
+     * @param StoreInterface $store
+     * @param HTTPRequest $request
+     * @return bool
+     */
+    protected function verifyLoginRequest(StoreInterface $store, HTTPRequest $request): bool
+    {
+        $method = $store->getMethod();
+        $methodInstance = $method ? $this->getMethodRegistry()->getMethodByURLSegment($method) : null;
+
+        // The method must be tracked in session. If it's missing we can't continue
+        if (!$methodInstance) {
+            throw new InvalidMethodException('There is no method tracked in a store for this request');
+        }
+
+        // Get the member and authenticator ready
+        $member = $store->getMember();
+        $registeredMethod = $this->getRegisteredMethodManager()->getFromMember($member, $methodInstance);
+        $authenticator = $registeredMethod->getLoginHandler();
+
+        if ($authenticator->verify($request, $store, $registeredMethod)) {
+            $store->addVerifiedMethod($method);
+            $store->save($request);
+            $this->extend('onMethodVerificationSuccess', $member, $methodInstance);
+            return true;
+        }
+
+        $this->extend('onMethodVerificationFailure', $member, $methodInstance);
+        return false;
+    }
+
+    /**
+     * Indicates the current member has verified with MFA methods enough to be considered "verified"
+     *
+     * @param StoreInterface $store
+     * @return bool
+     */
+    protected function isLoginComplete(StoreInterface $store)
+    {
+        // Pull the successful methods from session
+        $successfulMethods = $store->getVerifiedMethods();
+
+        // Zero is "not complete". There's different config for optional MFA
+        if (!is_array($successfulMethods) || !count($successfulMethods)) {
+            return false;
+        }
+
+        return count($successfulMethods) >= Config::inst()->get(EnforcementManager::class, 'required_mfa_methods');
+    }
+
+    /**
+     * Respond with the given array as a JSON response
+     *
+     * @param array $response
+     * @return HTTPResponse
+     */
+    protected function jsonResponse(array $response, $code = 200)
+    {
+        return HTTPResponse::create(json_encode($response))
+            ->addHeader('Content-Type', 'application/json')
+            ->setStatusCode($code);
+    }
+}

--- a/src/Service/EnforcementManager.php
+++ b/src/Service/EnforcementManager.php
@@ -19,6 +19,14 @@ class EnforcementManager
     use Injectable;
 
     /**
+     * Indicate how many MFA methods the user must authenticate with before they are considered logged in
+     *
+     * @config
+     * @var int
+     */
+    private static $required_mfa_methods = 1;
+
+    /**
      * Whether the current member can skip the multi factor authentication registration process.
      *
      * This is determined by a combination of:

--- a/src/Service/MethodRegistry.php
+++ b/src/Service/MethodRegistry.php
@@ -37,6 +37,13 @@ class MethodRegistry
     private static $default_backup_method = Method::class;
 
     /**
+     * Request cache of instantiated method instances
+     *
+     * @var array
+     */
+    protected $methodInstances;
+
+    /**
      * Get implementations of all configured methods
      *
      * @return MethodInterface[]
@@ -44,6 +51,10 @@ class MethodRegistry
      */
     public function getMethods()
     {
+        if (is_array($this->methodInstances)) {
+            return $this->methodInstances;
+        }
+
         $configuredMethods = (array) $this->config()->get('methods');
 
         $allMethods = [];
@@ -62,7 +73,7 @@ class MethodRegistry
             $allMethods[] = $method;
         }
 
-        return $allMethods;
+        return $this->methodInstances = $allMethods;
     }
 
     /**

--- a/src/Service/MethodRegistry.php
+++ b/src/Service/MethodRegistry.php
@@ -39,7 +39,7 @@ class MethodRegistry
     /**
      * Request cache of instantiated method instances
      *
-     * @var array
+     * @var MethodInterface[]
      */
     protected $methodInstances;
 

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -101,7 +101,7 @@ class SessionStore implements StoreInterface, Serializable
      */
     public function setMethod($method): StoreInterface
     {
-        if (in_array($method, $this->verifiedMethods)) {
+        if (in_array($method, $this->getVerifiedMethods())) {
             throw new InvalidMethodException('You cannot verify with a method you have already verified');
         }
 

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -2,7 +2,9 @@
 
 namespace SilverStripe\MFA\Store;
 
+use Serializable;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\MFA\Exception\InvalidMethodException;
 use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
@@ -13,7 +15,7 @@ use SilverStripe\Security\Member;
  *
  * @package SilverStripe\MFA
  */
-class SessionStore implements StoreInterface
+class SessionStore implements StoreInterface, Serializable
 {
     const SESSION_KEY = 'MFASessionStore';
 
@@ -39,22 +41,20 @@ class SessionStore implements StoreInterface
     protected $state = [];
 
     /**
+     * The URL segment identifiers of methods that have been verified in this session
+     *
+     * @var string[]
+     */
+    protected $verifiedMethods = [];
+
+    /**
      * Attempt to create a store from the given request getting any existing state from the session of the request
      *
      * {@inheritdoc}
      */
-    public function __construct(HTTPRequest $request = null)
+    public function __construct(Member $member)
     {
-        $state = $request ? $request->getSession()->get(static::SESSION_KEY) : null;
-
-        if ($state && $state['member']) {
-            /** @var Member $member */
-            $member = DataObject::get_by_id(Member::class, $state['member']);
-
-            $this->setMember($member);
-            $this->setMethod($state['method']);
-            $this->setState($state['state']);
-        }
+        $this->setMember($member);
     }
 
     /**
@@ -81,6 +81,9 @@ class SessionStore implements StoreInterface
 
         $this->member = $member;
 
+        // When the member changes the list of verified methods should reset
+        $this->verifiedMethods = [];
+
         return $this;
     }
 
@@ -98,6 +101,10 @@ class SessionStore implements StoreInterface
      */
     public function setMethod($method): StoreInterface
     {
+        if (in_array($method, $this->verifiedMethods)) {
+            throw new InvalidMethodException('You cannot verify with a method you have already verified');
+        }
+
         $this->method = $method;
 
         return $this;
@@ -115,6 +122,20 @@ class SessionStore implements StoreInterface
         return $this;
     }
 
+    public function addVerifiedMethod(string $method): StoreInterface
+    {
+        if (!in_array($method, $this->verifiedMethods)) {
+            $this->verifiedMethods[] = $method;
+        }
+
+        return $this;
+    }
+
+    public function getVerifiedMethods(): array
+    {
+        return $this->verifiedMethods;
+    }
+
     /**
      * Save this store into the session of the given request
      *
@@ -122,9 +143,21 @@ class SessionStore implements StoreInterface
      */
     public function save(HTTPRequest $request): StoreInterface
     {
-        $request->getSession()->set(static::SESSION_KEY, $this->build());
+        $request->getSession()->set(static::SESSION_KEY, $this);
 
         return $this;
+    }
+
+    /**
+     * Load a StoreInterface from the given request and return it if it exists
+     *
+     * @param HTTPRequest $request
+     * @return StoreInterface|null
+     */
+    public static function load(HTTPRequest $request): ?StoreInterface
+    {
+        $store = $request->getSession()->get(static::SESSION_KEY);
+        return $store instanceof self ? $store : null;
     }
 
     /**
@@ -137,6 +170,11 @@ class SessionStore implements StoreInterface
         $request->getSession()->clear(static::SESSION_KEY);
     }
 
+    /**
+     * "Reset" the method currently in progress by clearing the identifier and state
+     *
+     * @return StoreInterface
+     */
     protected function resetMethod(): StoreInterface
     {
         $this->setMethod(null)->setState([]);
@@ -144,12 +182,33 @@ class SessionStore implements StoreInterface
         return $this;
     }
 
-    protected function build(): array
+    public function serialize(): string
     {
-        return [
+        $stuff = json_encode([
             'member' => $this->getMember() ? $this->getMember()->ID : null,
             'method' => $this->getMethod(),
             'state' => $this->getState(),
-        ];
+            'verifiedMethods' => $this->getVerifiedMethods(),
+        ]);
+
+        return $stuff;
+    }
+
+    public function unserialize($serialized): void
+    {
+        $state = json_decode($serialized, true);
+
+        if (is_array($state) && $state['member']) {
+            /** @var Member $member */
+            $member = DataObject::get_by_id(Member::class, $state['member']);
+
+            $this->setMember($member);
+            $this->setMethod($state['method']);
+            $this->setState($state['state']);
+
+            foreach ($state['verifiedMethods'] as $method) {
+                $this->addVerifiedMethod($method);
+            }
+        }
     }
 }

--- a/src/Store/StoreInterface.php
+++ b/src/Store/StoreInterface.php
@@ -14,9 +14,9 @@ interface StoreInterface
     /**
      * Create a new StoreInterface, optionally given an HTTPRequest object
      *
-     * @param HTTPRequest|null $request
+     * @param Member $member
      */
-    public function __construct(?HTTPRequest $request = null);
+    public function __construct(Member $member);
 
     /**
      * Persist the stored state for the given request
@@ -25,6 +25,14 @@ interface StoreInterface
      * @return StoreInterface
      */
     public function save(HTTPRequest $request): StoreInterface;
+
+    /**
+     * Load a StoreInterface from the given request and return it if it exists
+     *
+     * @param HTTPRequest $request
+     * @return StoreInterface|null
+     */
+    public static function load(HTTPRequest $request): ?StoreInterface;
 
     /**
      * Clear any stored state for the given request
@@ -70,4 +78,19 @@ interface StoreInterface
      * @return $this
      */
     public function setMethod($method): StoreInterface;
+
+    /**
+     * Add and keep track of methods that have been verified
+     *
+     * @param string $method
+     * @return StoreInterface
+     */
+    public function addVerifiedMethod(string $method): StoreInterface;
+
+    /**
+     * Get the list of methods that have been verified
+     *
+     * @return string[]
+     */
+    public function getVerifiedMethods(): array;
 }

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -182,7 +182,7 @@ class LoginHandlerTest extends FunctionalTest
         $this->setSiteConfig(['MFARequired' => $mfaRequired]);
 
         if ($member) {
-            $this->logInAs($member);
+            $this->scaffoldPartialLogin($this->objFromFixture(Member::class, $member));
         }
 
         $response = $this->get('Security/login/default/mfa/skip');
@@ -195,7 +195,7 @@ class LoginHandlerTest extends FunctionalTest
     public function cannotSkipMFAProvider()
     {
         return [
-            'mfa is required' => [false],
+            'mfa is required' => [true],
             'mfa is not required, but user already has configured methods' => [false],
             'no member is available' => [false, null],
         ];
@@ -240,11 +240,7 @@ class LoginHandlerTest extends FunctionalTest
     {
         $this->logOut();
 
-        $this->session()->set(SessionStore::SESSION_KEY, [
-            'member' => $member->ID,
-            'method' => null,
-            'state' => [],
-        ]);
+        $this->session()->set(SessionStore::SESSION_KEY, new SessionStore($member));
     }
 
     /**

--- a/tests/php/Authenticator/RegisterHandlerTest.php
+++ b/tests/php/Authenticator/RegisterHandlerTest.php
@@ -217,10 +217,11 @@ class RegisterHandlerTest extends FunctionalTest
     {
         $this->logOut();
 
-        $this->session()->set(SessionStore::SESSION_KEY, [
-            'member' => $member->ID,
-            'method' => $method,
-            'state' => [],
-        ]);
+        $store = new SessionStore($member);
+        if ($method) {
+            $store->setMethod($method);
+        }
+
+        $this->session()->set(SessionStore::SESSION_KEY, $store);
     }
 }


### PR DESCRIPTION
- Moves configuration for the required number of verified methods to the EnforcementManager
- `StoreInterface` now requires a member. A store cannot be created without one
- Parts of the code have been updated to handle the new `?StoreInterface` return type of `getStore`
- Updated API responses to return `403` instead of redirects when session timeouts occur
- Added a `LoginHandler` trait that provides methods for handling requests and responses to and from the MFA React app
- `SessionStore` implements `Serializable` so it can be added to the session directly
- Moved tracking of completed "verified methods" to `StoreInterface`.
- Moved loading of existing `StoreInterface`s to the interface