### PR TITLE
NEW Add extension points for audit logging in method registration, login and skip points

### DIFF
--- a/src/Service/RegisteredMethodManager.php
+++ b/src/Service/RegisteredMethodManager.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\MFA\Service;
 
+use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\MFA\Method\MethodInterface;
@@ -14,6 +15,7 @@ use SilverStripe\Security\Member;
  */
 class RegisteredMethodManager
 {
+    use Extensible;
     use Injectable;
 
     /**
@@ -56,5 +58,7 @@ class RegisteredMethodManager
 
         // Add it to the member
         $member->RegisteredMFAMethods()->add($registeredMethod);
+
+        $this->extend('onRegisterMethod', $member, $method);
     }
 }


### PR DESCRIPTION
Issue: #24

Also adds `$member->registerLoginFailure()` in order to track login attempts in auditor. This is not a complete implementation of #47, but is the start of it. The UI still needs to lock you out or redirect you away to somewhere else when you're locked out in the DB.