### PR TITLE
API LoginHandler uses Result object instead of booleans, member is locked out via backend API after too many attempts

### DIFF
--- a/src/BackupCode/LoginHandler.php
+++ b/src/BackupCode/LoginHandler.php
@@ -7,6 +7,7 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\MFA\Method\Handler\LoginHandlerInterface;
 use SilverStripe\MFA\Model\RegisteredMethod;
+use SilverStripe\MFA\State\Result;
 use SilverStripe\MFA\Store\StoreInterface;
 
 class LoginHandler implements LoginHandlerInterface
@@ -35,10 +36,9 @@ class LoginHandler implements LoginHandlerInterface
      * @param HTTPRequest $request
      * @param StoreInterface $store
      * @param RegisteredMethod $registeredMethod The RegisteredMethod instance that is being verified
-     * @return bool
+     * @return Result
      */
-    public function verify(HTTPRequest $request, StoreInterface $store, RegisteredMethod $registeredMethod): bool
-    {
+    public function verify(HTTPRequest $request, StoreInterface $store, RegisteredMethod $registeredMethod): Result {
         $bodyJSON = json_decode($request->getBody(), true);
 
         if (!isset($bodyJSON['code'])) {
@@ -57,11 +57,11 @@ class LoginHandler implements LoginHandlerInterface
                 array_splice($candidates, $index, 1);
                 $registeredMethod->Data = json_encode($candidates);
                 $registeredMethod->write();
-                return true;
+                return Result::create();
             }
         }
 
-        return false;
+        return Result::create(false, _t(__CLASS__ . '.INVALID_CODE', 'Invalid code'));
     }
 
     /**

--- a/src/BackupCode/LoginHandler.php
+++ b/src/BackupCode/LoginHandler.php
@@ -38,7 +38,8 @@ class LoginHandler implements LoginHandlerInterface
      * @param RegisteredMethod $registeredMethod The RegisteredMethod instance that is being verified
      * @return Result
      */
-    public function verify(HTTPRequest $request, StoreInterface $store, RegisteredMethod $registeredMethod): Result {
+    public function verify(HTTPRequest $request, StoreInterface $store, RegisteredMethod $registeredMethod): Result
+    {
         $bodyJSON = json_decode($request->getBody(), true);
 
         if (!isset($bodyJSON['code'])) {

--- a/src/Method/Handler/LoginHandlerInterface.php
+++ b/src/Method/Handler/LoginHandlerInterface.php
@@ -4,6 +4,7 @@ namespace SilverStripe\MFA\Method\Handler;
 
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\MFA\Model\RegisteredMethod;
+use SilverStripe\MFA\State\Result;
 use SilverStripe\MFA\Store\StoreInterface;
 
 /**
@@ -29,9 +30,9 @@ interface LoginHandlerInterface
      * @param HTTPRequest $request
      * @param StoreInterface $store
      * @param RegisteredMethod $registeredMethod The RegisteredMethod instance that is being verified
-     * @return bool
+     * @return Result
      */
-    public function verify(HTTPRequest $request, StoreInterface $store, RegisteredMethod $registeredMethod): bool;
+    public function verify(HTTPRequest $request, StoreInterface $store, RegisteredMethod $registeredMethod): Result;
 
     /**
      * Provide a localised string that serves as a lead in for choosing this option for authentication

--- a/src/State/Result.php
+++ b/src/State/Result.php
@@ -73,7 +73,7 @@ class Result
      * @param bool $success
      * @return Result
      */
-    public function setSuccess(bool $success): Result
+    public function setSuccessful(bool $success): Result
     {
         return new static($success, $this->getMessage(), $this->getContext());
     }

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -119,7 +119,12 @@ class SessionStore implements StoreInterface, Serializable
     public function setState(array $state): StoreInterface
     {
         $this->state = $state;
+        return $this;
+    }
 
+    public function addState(array $state): StoreInterface
+    {
+        $this->state = array_merge($this->state, $state);
         return $this;
     }
 

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\MFA\Store;
 
+use RuntimeException;
 use Serializable;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\MFA\Exception\InvalidMethodException;
@@ -190,6 +191,10 @@ class SessionStore implements StoreInterface, Serializable
             'state' => $this->getState(),
             'verifiedMethods' => $this->getVerifiedMethods(),
         ]);
+
+        if (!$stuff) {
+            throw new RuntimeException(json_last_error_msg());
+        }
 
         return $stuff;
     }

--- a/src/Store/StoreInterface.php
+++ b/src/Store/StoreInterface.php
@@ -50,12 +50,20 @@ interface StoreInterface
     public function getState(): array;
 
     /**
-     * Update the state in the store
+     * Update the state in the store. Will override existing state. To add to the existing state use addState().
      *
      * @param array $state
      * @return StoreInterface
      */
     public function setState(array $state): StoreInterface;
+
+    /**
+     * Add to the state in the store
+     *
+     * @param array $state
+     * @return StoreInterface
+     */
+    public function addState(array $state): StoreInterface;
 
     /**
      * @return Member&MemberExtension|null

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -259,6 +259,7 @@ class LoginHandlerTest extends FunctionalTest
     {
         /** @var Member&MemberExtension $member */
         $member = $this->objFromFixture(Member::class, 'robbie');
+        $member->config()->set('lock_out_after_incorrect_logins', 5);
         $failedLogins = $member->FailedLoginCount;
 
         /** @var LoginHandler|PHPUnit_Framework_MockObject_MockObject $handler */

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\MFA\Tests\Authenticator;
 
+use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Session;
@@ -14,6 +15,7 @@ use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\MFA\Method\MethodInterface;
 use SilverStripe\MFA\Model\RegisteredMethod;
 use SilverStripe\MFA\Service\MethodRegistry;
+use SilverStripe\MFA\State\Result;
 use SilverStripe\MFA\Store\SessionStore;
 use SilverStripe\MFA\Tests\Stub\BasicMath\Method;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -251,6 +253,35 @@ class LoginHandlerTest extends FunctionalTest
         $response = $handler->verifyLogin($request);
         $this->assertEquals(403, $response->getStatusCode());
         $this->assertContains('Your account is temporarily locked', (string) $response->getBody());
+    }
+
+    public function testVerifyLoginPassesExceptionMessagesThroughFromMethodsWithValidationFailures()
+    {
+        /** @var Member&MemberExtension $member */
+        $member = $this->objFromFixture(Member::class, 'robbie');
+        $failedLogins = $member->FailedLoginCount;
+
+        /** @var LoginHandler|PHPUnit_Framework_MockObject_MockObject $handler */
+        $handler = $this->getMockBuilder(LoginHandler::class)
+            ->setMethods(['verifyLoginRequest'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $handler->expects($this->once())->method('verifyLoginRequest')->willReturn(
+            Result::create(false, 'It failed because it\'s mocked, obviously')
+        );
+
+        $request = new HTTPRequest('GET', '/');
+        $request->setSession(new Session([]));
+        $store = new SessionStore($member);
+        $store->setMethod('basic-math');
+        $handler->setStore($store);
+
+        $response = $handler->verifyLogin($request);
+
+        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertContains('It failed because it\'s mocked', (string) $response->getBody());
+        $this->assertSame($failedLogins + 1, $member->FailedLoginCount, 'Failed login is registered');
     }
 
     /**

--- a/tests/php/BackupCode/LoginHandlerTest.php
+++ b/tests/php/BackupCode/LoginHandlerTest.php
@@ -25,7 +25,7 @@ class LoginHandlerTest extends SapphireTest
 
         // Test a code with invalid characters
         list ($request, $store, $method) = $this->scaffoldVerifyParams($input);
-        $this->assertSame($expectedResult, $handler->verify($request, $store, $method), $message);
+        $this->assertSame($expectedResult, $handler->verify($request, $store, $method)->isSuccessful(), $message);
     }
 
     public function testVerifyInvalidatesCodesThatHaveBeenUsed()
@@ -34,7 +34,7 @@ class LoginHandlerTest extends SapphireTest
 
         // Test a code with invalid characters
         list ($request, $store, $method) = $this->scaffoldVerifyParams('123456');
-        $this->assertTrue($handler->verify($request, $store, $method));
+        $this->assertTrue($handler->verify($request, $store, $method)->isSuccessful());
 
         $method = DataObject::get_by_id(RegisteredMethod::class, $method->ID);
         $codes = json_decode($method->Data, true);
@@ -43,7 +43,7 @@ class LoginHandlerTest extends SapphireTest
 
         list ($request, $store, $method) = $this->scaffoldVerifyParams('123456');
         $this->assertFalse(
-            $handler->verify($request, $store, $method),
+            $handler->verify($request, $store, $method)->isSuccessful(),
             'Attempting to validate the previously used code now returns false'
         );
     }

--- a/tests/php/BasicMath/MethodLoginHandlerTest.php
+++ b/tests/php/BasicMath/MethodLoginHandlerTest.php
@@ -40,6 +40,6 @@ class MethodLoginHandlerTest extends SapphireTest
 
         $mockRegisteredMethod = RegisteredMethod::create();
 
-        $this->assertTrue($handler->verify($request, $store, $mockRegisteredMethod));
+        $this->assertTrue($handler->verify($request, $store, $mockRegisteredMethod)->isSuccessful());
     }
 }

--- a/tests/php/State/ResultTest.php
+++ b/tests/php/State/ResultTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\State;
+
+use PHPUnit\Framework\TestCase;
+use SilverStripe\MFA\State\Result;
+
+class ResultTest extends TestCase
+{
+    public function testSetContext()
+    {
+        $result = new Result(false, 'Oops!', ['tired' => true]);
+        $newResult = $result->setContext(['tired' => false]);
+        $this->assertNotSame($result->getContext(), $newResult->getContext(), 'Result should be immutable');
+    }
+
+    public function testGetContext()
+    {
+        $result = new Result(true, 'Test', ['foo' => 'bar']);
+        $this->assertSame(['foo' => 'bar'], $result->getContext());
+    }
+
+    public function testSetMessage()
+    {
+        $result = new Result();
+        $newResult = $result->setMessage('foo');
+        $this->assertNotSame($result->getMessage(), $newResult->getMessage(), 'Result should be immutable');
+    }
+
+    public function testGetMessage()
+    {
+        $result = new Result(true, 'Hello');
+        $this->assertSame('Hello', $result->getMessage());
+    }
+
+    public function testIsSuccessful()
+    {
+        $result = new Result(false);
+        $this->assertFalse($result->isSuccessful());
+    }
+
+    public function testSetSuccess()
+    {
+        $result = new Result(false);
+        $newResult = $result->setSuccessful(true);
+        $this->assertNotSame($result->isSuccessful(), $newResult->isSuccessful(), 'Result should be immutable');
+    }
+}

--- a/tests/php/Store/SessionStoreTest.php
+++ b/tests/php/Store/SessionStoreTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\Store;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\MFA\Store\SessionStore;
+use SilverStripe\Security\Member;
+
+class SessionStoreTest extends SapphireTest
+{
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessageRegExp /possibly incorrectly encoded/
+     */
+    public function testSerializeThrowsExceptionOnFailure()
+    {
+        $store = new SessionStore($this->createMock(Member::class));
+        $store->setState(['some binary' => random_bytes(32)]);
+        $store->serialize();
+    }
+
+    public function testSetState()
+    {
+        $store = new SessionStore($this->createMock(Member::class));
+        $store->setState(['foo' => 'bar']);
+        $this->assertSame(['foo' => 'bar'], $store->getState());
+    }
+
+    public function testAddState()
+    {
+        $store = new SessionStore($this->createMock(Member::class));
+        $store->setState(['foo' => 'bar', 'bar' => 'baz']);
+        $store->addState(['foo' => 'baz']);
+        $this->assertSame(['foo' => 'baz', 'bar' => 'baz'], $store->getState());
+    }
+
+    /**
+     * @expectedException \SilverStripe\MFA\Exception\InvalidMethodException
+     * @expectedExceptionMessage You cannot verify with a method you have already verified
+     */
+    public function testSetMethodWithVerifiedMethod()
+    {
+        $store = new SessionStore($this->createMock(Member::class));
+        $store->addVerifiedMethod('foobar');
+        $store->setMethod('foobar');
+    }
+
+    public function testSetMethod()
+    {
+        $store = new SessionStore($this->createMock(Member::class));
+        $store->setMethod('foobar');
+        $this->assertSame('foobar', $store->getMethod());
+    }
+
+    public function testSetMemberDoesNotResetMethodsWhenNoChange()
+    {
+        $member1 = $this->createMock(Member::class);
+
+        $store = new SessionStore($member1);
+        $store->setMethod('foobar');
+        $store->addVerifiedMethod('foobar');
+        $store->setMember($member1);
+
+        $this->assertSame('foobar', $store->getMethod());
+    }
+
+    public function testSetMemberResetsMethodsWhenMemberChanged()
+    {
+        $member1 = new Member();
+        $member1->ID = 25;
+        $member2 = new Member();
+        $member2->ID = 50;
+
+        $store = new SessionStore($member1);
+        $store->setMethod('foobar');
+        $store->addVerifiedMethod('foobar');
+        $store->setMember($member2);
+
+        $this->assertEmpty($store->getMethod());
+    }
+}


### PR DESCRIPTION
* Return Result objects instead of booleans from verify() and subsequent methods, so we can communicate context to the frontend
* Add handling for when the member is locked out and pass it to the frontend
* Failures to handle JSON encoding of the state now throws an exception instead of a PHP type error (returning bool when should return string from serialize())

Resolves #47