### PR TITLE
API Moving registration logic to a trait for easier re-usability

### DIFF
--- a/src/BackupCode/RegisterHandler.php
+++ b/src/BackupCode/RegisterHandler.php
@@ -11,6 +11,7 @@ use SilverStripe\MFA\Method\Handler\RegisterHandlerInterface;
 use SilverStripe\MFA\Method\MethodInterface;
 use SilverStripe\MFA\Service\BackupCodeGeneratorInterface;
 use SilverStripe\MFA\Service\RegisteredMethodManager;
+use SilverStripe\MFA\State\Result;
 use SilverStripe\MFA\Store\StoreInterface;
 
 class RegisterHandler implements RegisterHandlerInterface
@@ -62,10 +63,10 @@ class RegisterHandler implements RegisterHandlerInterface
      * @param StoreInterface $store
      * @return array
      */
-    public function register(HTTPRequest $request, StoreInterface $store): array
+    public function register(HTTPRequest $request, StoreInterface $store): Result
     {
         // Backup codes are unique where no confirmation or user input is required. The method is registered on "start"
-        return [];
+        return Result::create();
     }
 
     /**

--- a/src/Exception/RegistrationFailedException.php
+++ b/src/Exception/RegistrationFailedException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SilverStripe\MFA\Exception;
+
+use LogicException;
+
+class RegistrationFailedException extends LogicException
+{
+
+}

--- a/src/Method/Handler/RegisterHandlerInterface.php
+++ b/src/Method/Handler/RegisterHandlerInterface.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\MFA\Method\Handler;
 
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\MFA\State\Result;
 use SilverStripe\MFA\Store\StoreInterface;
 
 /**
@@ -21,16 +22,14 @@ interface RegisterHandlerInterface
     public function start(StoreInterface $store): array;
 
     /**
-     * Confirm that the provided details are valid, and return an array of "data" to store on the RegisteredMethod
-     * created for this registration.
-     *
-     * An Exception should be thrown if the registration could not be completed
+     * Confirm that the provided details are valid for a registration returning a Result describing the outcome of this
+     * validation. Detail to be persisted against the member should be set as context on the result.
      *
      * @param HTTPRequest $request
      * @param StoreInterface $store
-     * @return array Data to be stored against the created RegisteredMethod
+     * @return Result A result of this registration with context set as data to be stored against the RegisteredMethod
      */
-    public function register(HTTPRequest $request, StoreInterface $store): array;
+    public function register(HTTPRequest $request, StoreInterface $store): Result;
 
     /**
      * Provide a localised name for this MFA Method.

--- a/src/RequestHandler/BaseHandlerTrait.php
+++ b/src/RequestHandler/BaseHandlerTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SilverStripe\MFA\RequestHandler;
+
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\MFA\Service\MethodRegistry;
+use SilverStripe\MFA\Service\RegisteredMethodManager;
+use SilverStripe\MFA\Store\StoreInterface;
+use SilverStripe\Security\Member;
+use SilverStripe\View\Requirements;
+
+trait BaseHandlerTrait
+{
+    /**
+     * Perform the necessary "Requirements" calls to ensure client side scripts are available in the response
+     */
+    protected function applyRequirements(): void
+    {
+        // Run through requirements
+        Requirements::javascript('silverstripe/mfa: client/dist/js/injector.js');
+        Requirements::javascript('silverstripe/admin: client/dist/js/i18n.js');
+        Requirements::javascript('silverstripe/mfa: client/dist/js/bundle.js');
+        Requirements::add_i18n_javascript('silverstripe/mfa: client/lang');
+        Requirements::css('silverstripe/mfa: client/dist/styles/bundle.css');
+
+        // Plugin module requirements
+        foreach (MethodRegistry::singleton()->getMethods() as $method) {
+            $method->applyRequirements();
+        }
+    }
+
+    /**
+     * @return StoreInterface|null
+     */
+    protected function getStore(): ?StoreInterface
+    {
+        if (!$this->store) {
+            $spec = Injector::inst()->getServiceSpec(StoreInterface::class);
+            $class = is_string($spec) ? $spec : $spec['class'];
+            $this->store = call_user_func([$class, 'load'], $this->getRequest());
+        }
+
+        return $this->store;
+    }
+
+    /**
+     * @param Member $member
+     * @return StoreInterface
+     */
+    protected function createStore(Member $member): StoreInterface
+    {
+        $store = Injector::inst()->create(StoreInterface::class, $member);
+        // Ensure use of the getter returns the new store
+        $this->store = $store;
+        return $store;
+    }
+}

--- a/src/RequestHandler/RegistrationHandlerTrait.php
+++ b/src/RequestHandler/RegistrationHandlerTrait.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SilverStripe\MFA\RequestHandler;
+
+use Exception;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\MFA\Method\MethodInterface;
+use SilverStripe\MFA\Service\RegisteredMethodManager;
+use SilverStripe\MFA\State\Result;
+use SilverStripe\MFA\Store\StoreInterface;
+use SilverStripe\ORM\ValidationResult;
+
+/**
+ * This trait encapsulates logic that can be added to a `RequestHandler` to work with registering MFA authenticators
+ * using the MFA front-end app. It provides two main methods; @see createStartRegistrationResponse - creates a response
+ * that can be easily consumed by the MFA app to start the registration process for a method, and
+ * @see completeRegistrationRequest - used to complete the registration flow for a method using details sent back by the
+ * MFA app.
+ */
+trait RegistrationHandlerTrait
+{
+    public function createStartRegistrationResponse(StoreInterface $store, MethodInterface $method): HTTPResponse
+    {
+        $member = $store->getMember();
+
+        // Sanity check that the method hasn't already been registered
+        $existingRegisteredMethod = RegisteredMethodManager::singleton()->getFromMember($member, $method);
+
+        $response = HTTPResponse::create()
+            ->addHeader('Content-Type', 'application/json');
+
+        if ($existingRegisteredMethod) {
+            return $response->setBody(json_encode(['errors' => [_t(
+                __CLASS__ . '.METHOD_ALREADY_REGISTERED',
+                'That method has already been registered against this Member'
+            )]]))->setStatusCode(400);
+        }
+
+        // Mark the given method as started within the session
+        $store->setMethod($method->getURLSegment());
+        // Allow the registration handler to begin the process and generate some data to pass through to the front-end
+        $data = $method->getRegisterHandler()->start($store);
+
+        return $response->setBody(json_encode($data));
+    }
+
+    public function completeRegistrationRequest(
+        StoreInterface $store,
+        MethodInterface $method,
+        HTTPRequest $request
+    ): Result {
+        $storedMethodName = $store->getMethod();
+
+        // If a registration process hasn't been initiated in a previous request, calling this method is invalid
+        if (!$storedMethodName) {
+            return Result::create(false, _t(__CLASS__ . '.NO_REGISTRATION_IN_PROGRESS', 'No registration in progress'));
+        }
+
+        // Assert the method in progress matches the request for completion
+        if ($storedMethodName !== $method->getURLSegment()) {
+            return Result::create(
+                false,
+                _t(__CLASS__ . '.METHOD_MISMATCH', 'Method does not match registration in progress')
+            );
+        }
+
+        $registrationHandler = $method->getRegisterHandler();
+        $result = $registrationHandler->register($request, $store);
+
+        $member = $store->getMember();
+        if ($result->isSuccessful()) {
+            RegisteredMethodManager::singleton()
+                ->registerForMember($member, $method, $result->getContext());
+        } else {
+            $this->extend('onRegisterMethodFailure', $member, $method);
+        }
+
+        return $result;
+    }
+}

--- a/src/State/Result.php
+++ b/src/State/Result.php
@@ -7,6 +7,8 @@ use SilverStripe\Core\Injector\Injectable;
 /**
  * An immutable result object often detailing the result of a registration or validation completed by the
  * respective handlers
+ *
+ * @method static create(bool $success = true, string $message = '', array $context = [])
  */
 class Result
 {

--- a/tests/php/Authenticator/RegisterHandlerTest.php
+++ b/tests/php/Authenticator/RegisterHandlerTest.php
@@ -11,6 +11,7 @@ use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\MFA\Method\Handler\RegisterHandlerInterface;
 use SilverStripe\MFA\Method\MethodInterface;
 use SilverStripe\MFA\Service\MethodRegistry;
+use SilverStripe\MFA\State\Result;
 use SilverStripe\MFA\Store\SessionStore;
 use SilverStripe\MFA\Tests\Stub\BasicMath\Method;
 use SilverStripe\Security\Member;
@@ -153,7 +154,7 @@ class RegisterHandlerTest extends FunctionalTest
         $registerHandlerMock
             ->expects($this->once())
             ->method('register')
-            ->willThrowException(new Exception('No. Bad user'));
+            ->willReturn(Result::create(false, 'No. Bad user'));
 
         $methodMock = $this->createMock(MethodInterface::class);
         $methodMock

--- a/tests/php/BackupCode/RegisterHandlerTest.php
+++ b/tests/php/BackupCode/RegisterHandlerTest.php
@@ -71,7 +71,7 @@ class RegisterHandlerTest extends SapphireTest
         }
     }
 
-    public function testRegisterReturnsNothing()
+    public function testRegisterReturnsNoContext()
     {
         /** @var StoreInterface|PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->createMock(StoreInterface::class);
@@ -82,6 +82,7 @@ class RegisterHandlerTest extends SapphireTest
         $handler = new RegisterHandler();
         $result = $handler->register($request, $store);
 
-        $this->assertEmpty($result);
+        $this->assertTrue($result->isSuccessful());
+        $this->assertEmpty($result->getContext());
     }
 }

--- a/tests/php/Stub/BasicMath/MethodRegisterHandler.php
+++ b/tests/php/Stub/BasicMath/MethodRegisterHandler.php
@@ -2,10 +2,10 @@
 
 namespace SilverStripe\MFA\Tests\Stub\BasicMath;
 
-use RuntimeException;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\MFA\Method\Handler\RegisterHandlerInterface;
+use SilverStripe\MFA\State\Result;
 use SilverStripe\MFA\Store\StoreInterface;
 
 /**
@@ -30,18 +30,17 @@ class MethodRegisterHandler implements RegisterHandlerInterface, TestOnly
      *
      * @param HTTPRequest $request
      * @param StoreInterface $store
-     * @return array
-     * @throws RuntimeException When insufficient user input is provided
+     * @return Result
      */
-    public function register(HTTPRequest $request, StoreInterface $store): array
+    public function register(HTTPRequest $request, StoreInterface $store): Result
     {
         $parameters = json_decode($request->getBody(), true);
 
         if (!array_key_exists('number', $parameters)) {
-            throw new RuntimeException('The required user input was not provided to register this method');
+            return Result::create(false, 'The required user input was not provided to register this method');
         }
 
-        return ['number' => $parameters['number']];
+        return Result::create(true, '', ['number' => $parameters['number']]);
     }
 
     /**


### PR DESCRIPTION
- Created a new trait  that encapsulates logic for handling registration requests/responses to the MFA React App
- Created a  that has some methods for scaffolding the MFA React App not specific to either verification or registration