### PR TITLE
API BackupCodeGenerator::generate() now returns an array of BackupCode instances

### DIFF
--- a/src/Service/BackupCodeGenerator.php
+++ b/src/Service/BackupCodeGenerator.php
@@ -6,6 +6,7 @@ use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\MFA\Exception\HashFailedException;
+use SilverStripe\MFA\State\BackupCode;
 
 class BackupCodeGenerator implements BackupCodeGeneratorInterface
 {
@@ -46,14 +47,11 @@ class BackupCodeGenerator implements BackupCodeGeneratorInterface
         while (count($codes) < $codeCount) {
             $code = $this->generateCode($charset, $codeLength);
             if (!in_array($code, $codes)) {
-                $codes[] = $code;
+                $codes[] = BackupCode::create($code, $this->hash($code));
             }
         }
 
-        // Create hashes for the codes
-        $hashedCodes = array_map([$this, 'hash'], $codes);
-
-        return array_combine($codes, $hashedCodes);
+        return $codes;
     }
 
     /**

--- a/src/Service/BackupCodeGeneratorInterface.php
+++ b/src/Service/BackupCodeGeneratorInterface.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\MFA\Service;
 
 use SilverStripe\MFA\Exception\HashFailedException;
+use SilverStripe\MFA\State\BackupCode;
 
 /**
  * A service class implementation for generating and hashing backup codes.
@@ -10,9 +11,9 @@ use SilverStripe\MFA\Exception\HashFailedException;
 interface BackupCodeGeneratorInterface
 {
     /**
-     * Generate a list of backup codes and return them in a key -> value pair of plain text to hashed values.
+     * Generate a list of backup codes and return them in an array of state objects.
      *
-     * @return string[] Key value pairs of plaintext and hashes
+     * @return BackupCode[]
      */
     public function generate(): array;
 

--- a/src/State/BackupCode.php
+++ b/src/State/BackupCode.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\MFA\State;
+
+use SilverStripe\Core\Injector\Injectable;
+
+/**
+ * A container for a backup code and its hash, normally used during backup code generation
+ */
+class BackupCode
+{
+    use Injectable;
+
+    /**
+     * @var string
+     */
+    protected $code = '';
+
+    /**
+     * @var string
+     */
+    protected $hash = '';
+
+    /**
+     * @param string $code
+     * @param string $hash
+     */
+    public function __construct(string $code, string $hash)
+    {
+        $this->code = $code;
+        $this->hash = $hash;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getHash(): string
+    {
+        return $this->hash;
+    }
+}

--- a/tests/php/Service/BackupCodeGeneratorTest.php
+++ b/tests/php/Service/BackupCodeGeneratorTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\MFA\Service;
 
 use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\MFA\State\BackupCode;
 use SilverStripe\MFA\Tests\Service\BackupCodeGeneratorTest\MockHashExtension;
 
 class BackupCodeGeneratorTest extends SapphireTest
@@ -53,12 +54,21 @@ class BackupCodeGeneratorTest extends SapphireTest
     public function testGenerate()
     {
         $generator = new BackupCodeGenerator();
+        /** @var BackupCode[] $result */
         $result = $generator->generate();
 
         $this->assertCount(3, $result, 'Expected number of codes are generated');
-        foreach ($result as $code => $hash) {
-            $this->assertSame(6, strlen($code), 'Generated codes are of configured length');
-            $this->assertSame(strrev($code), $hash, 'Mock hashing method is used and hash is returned');
+        foreach ($result as $backupCode) {
+            $this->assertSame(
+                6,
+                strlen($backupCode->getCode()),
+                'Generated codes are of configured length'
+            );
+            $this->assertSame(
+                strrev($backupCode->getCode()),
+                $backupCode->getHash(),
+                'Mock hashing method is used and hash is returned'
+            );
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-mfa/issues/111

This fixes an issue where PHP would coerce numeric strings to ints. They are always strings now.