### PR TITLE
Add safety to store access in finishRegistration

### DIFF
--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -236,7 +236,7 @@ class LoginHandler extends BaseLoginHandler
     public function finishRegistration(HTTPRequest $request)
     {
         $store = $this->getStore();
-        $sessionMember = $store->getMember();
+        $sessionMember = $store ? $store->getMember() : null;
         $loggedInMember = Security::getCurrentUser();
 
         if (is_null($loggedInMember) && is_null($sessionMember)) {


### PR DESCRIPTION
This was causing a test failure on my local environment. Not sure why Travis would have different behaviour, but this is a valid safety improvement regardless.