### PR TITLE
Add silverstripe/login-forms as direct dependency of silverstripe/mfa

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "php": ">=7.1.0",
         "silverstripe/framework": "^4",
         "silverstripe/siteconfig": "^4",
-        "defuse/php-encryption": "^2.2"
+        "defuse/php-encryption": "^2.2",
+        "silverstripe/login-forms": "1.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
We are testing our designs based on their output with the login-forms module installed. This will be the preferred approach to using the MFA module.

Resolves #95.