### PR TITLE
FIX MFA notifications can now be disabled via configuration

### DIFF
--- a/src/Service/Notification.php
+++ b/src/Service/Notification.php
@@ -5,16 +5,18 @@ namespace SilverStripe\MFA\Service;
 use Exception;
 use Psr\Log\LoggerInterface;
 use SilverStripe\Control\Email\Email;
+use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Security\Member;
 
 /**
- * Ecapsulates setting up an Email in order to allow for Dependency Injection and to avoid introducing a hard
+ * Encapsulates setting up an Email in order to allow for dependency injection and to avoid introducing a hard
  * coupling to the SilverStripe core Email class in code that consumes this class.
  */
 class Notification
 {
+    use Configurable;
     use Injectable;
     use Extensible;
 
@@ -25,6 +27,14 @@ class Notification
     private static $dependencies = [
         'Logger' => '%$' . LoggerInterface::class . '.mfa',
     ];
+
+    /**
+     * Whether sending emails is enabled for MFA changes
+     *
+     * @config
+     * @var bool
+     */
+    private static $enabled = true;
 
     /**
      * @var LoggerInterface
@@ -52,6 +62,10 @@ class Notification
      */
     public function send(Member $member, string $template, array $data = []): bool
     {
+        if (!$this->config()->get('enabled')) {
+            return false;
+        }
+
         // Catch exceptions with setting the "to" address and sending the email.
         try {
             $email = Email::create()

--- a/tests/php/Service/NotificationTest.php
+++ b/tests/php/Service/NotificationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SilverStripe\MFA\Service\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\MFA\Service\Notification;
+use SilverStripe\Security\Member;
+
+class NotificationTest extends SapphireTest
+{
+    public function testCanBeDisabled()
+    {
+        Notification::config()->set('enabled', false);
+        $result = Notification::create()->send($this->createMock(Member::class), 'foo');
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
This should've been part of the A/Cs (I don't remember if it was or not), but you should be able to turn off these notifications.