### PR TITLE
FIX ability to log in without MFA verification

### DIFF
--- a/src/Service/EnforcementManager.php
+++ b/src/Service/EnforcementManager.php
@@ -71,6 +71,10 @@ class EnforcementManager
      */
     public function shouldRedirectToMFA(Member $member): bool
     {
+        if ($member->RegisteredMFAMethods()->exists()) {
+            return true;
+        }
+
         if ($this->isMFARequired()) {
             return true;
         }

--- a/tests/php/Service/EnforcementManagerTest.php
+++ b/tests/php/Service/EnforcementManagerTest.php
@@ -72,6 +72,13 @@ class EnforcementManagerTest extends SapphireTest
         $this->assertTrue(EnforcementManager::create()->canSkipMFA($member));
     }
 
+    public function testShouldRedirectToMFAWhenUserHasRegisteredMFAMethod()
+    {
+        $member = $this->objFromFixture(Member::class, 'sally_smith');
+        $shouldRedirect = EnforcementManager::create()->shouldRedirectToMFA($member);
+        $this->assertTrue($shouldRedirect);
+    }
+
     public function testShouldRedirectToMFAWhenMFAIsRequired()
     {
         $this->setSiteConfig(['MFARequired' => true]);
@@ -100,7 +107,7 @@ class EnforcementManagerTest extends SapphireTest
         $this->setSiteConfig(['MFARequired' => false]);
 
         /** @var Member&MemberExtension $member */
-        $member = $this->objFromFixture(Member::class, 'sally_smith');
+        $member = $this->objFromFixture(Member::class, 'sammy_smith');
         $member->HasSkippedMFARegistration = true;
         $member->write();
         $this->logInAs($member);

--- a/tests/php/Service/EnforcementManagerTest.yml
+++ b/tests/php/Service/EnforcementManagerTest.yml
@@ -10,3 +10,7 @@ SilverStripe\Security\Member:
     RegisteredMFAMethods:
       - =>SilverStripe\MFA\Model\RegisteredMethod.codes
     DefaultRegisteredMethodID: =>SilverStripe\MFA\Model\RegisteredMethod.codes
+  sammy_smith:
+    FirstName: Sammy
+    Surname: Smith
+    Email: sammy.smith@example.com


### PR DESCRIPTION
During recent work to have MFA always enabled (#186) an oversight was made in testing
meaning that a user could log in without verifying their registered MFA methods, if the site
was set to have MFA as optional.