### PR TITLE
FIX Users without CMS access are now able to log in correctly

### DIFF
--- a/src/Service/EnforcementManager.php
+++ b/src/Service/EnforcementManager.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\MFA\Service;
 
+use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
@@ -10,7 +11,6 @@ use SilverStripe\MFA\Extension\SiteConfigExtension;
 use SilverStripe\ORM\FieldType\DBDate;
 use SilverStripe\Security\Member;
 use SilverStripe\SiteConfig\SiteConfig;
-use SilverStripe\SiteConfig\SiteConfigLeftAndMain;
 
 /**
  * The EnforcementManager class is responsible for making decisions regarding multi factor authentication app flow,
@@ -214,9 +214,7 @@ class EnforcementManager
      */
     protected function hasAdminAccess(Member $member): bool
     {
-        // We need to use an actual LeftAndMain implementation, otherwise LeftAndMain::canView() returns true
-        // because no required permission codes are declared
-        $leftAndMain = SiteConfigLeftAndMain::singleton();
+        $leftAndMain = LeftAndMain::singleton();
         if ($leftAndMain->canView($member)) {
             return true;
         }
@@ -225,7 +223,7 @@ class EnforcementManager
         $menu = $leftAndMain->MainMenu();
         foreach ($menu as $candidate) {
             if ($candidate->Link
-                && $candidate->Link != $leftAndMain->Link()
+                && $candidate->Link !== $leftAndMain->Link()
                 && $candidate->MenuItem->controller
                 && singleton($candidate->MenuItem->controller)->canView($member)
             ) {

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -411,6 +411,21 @@ class LoginHandlerTest extends FunctionalTest
         $this->assertSame($failedLogins + 1, $member->FailedLoginCount, 'Failed login is registered');
     }
 
+    public function testGetBackURL()
+    {
+        $handler = new LoginHandler('foo', $this->createMock(MemberAuthenticator::class));
+
+        $request = new HTTPRequest('GET', '/');
+        $handler->setRequest($request);
+
+        $session = new Session([]);
+        $request->setSession($session);
+
+        $session->set(LoginHandler::SESSION_KEY . '.additionalData', ['BackURL' => 'foobar']);
+
+        $this->assertSame('foobar', $handler->getBackURL());
+    }
+
     /**
      * Mark the given user as partially logged in - ie. they've entered their email/password and are currently going
      * through the MFA process

--- a/tests/php/Service/EnforcementManagerTest.php
+++ b/tests/php/Service/EnforcementManagerTest.php
@@ -100,6 +100,14 @@ class EnforcementManagerTest extends SapphireTest
         $this->assertTrue(EnforcementManager::create()->shouldRedirectToMFA($member));
     }
 
+    public function testShouldRedirectToMFAForContentAuthors()
+    {
+        $memberID = $this->logInWithPermission('CMS_ACCESS_CMSMain');
+        /** @var Member $member */
+        $member = Member::get()->byID($memberID);
+        $this->assertTrue(EnforcementManager::create()->shouldRedirectToMFA($member));
+    }
+
     public function testShouldRedirectToMFAWhenUserHasRegisteredMFAMethod()
     {
         /** @var Member $member */


### PR DESCRIPTION
This fixes an issue that would continue to redirect the user to MFA after they logged in, ending up in a redirect loop. This patch checks whether it should redirect to MFA as well as checking if the registration is not complete yet before executing this logic.

Fixes https://github.com/silverstripe/silverstripe-mfa/issues/204