### PR TITLE
WIP: NEW Add a basic Behat test to set MFA to be required, and ensure "I log in as" skips MFA registration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,38 @@
 language: php
 
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install chromium-chromedriver
+
 dist: trusty
 
 env:
   global:
     - TRAVIS_NODE_VERSION="10"
+    - DISPLAY=":99"
+    - XVFBARGS=":99 -ac -screen 0 1024x768x16"
+    - SS_BASE_URL="http://localhost:8080/"
+    - SS_ENVIRONMENT_TYPE="dev"
 
 matrix:
   include:
-    - php: 7.1
+    - php: '7.1'
       env: DB=MYSQL RECIPE_VERSION=4.2.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1
-    - php: 7.1
+    - php: '7.1'
       env: DB=PGSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_COVERAGE_TEST=1
-    - php: 7.2
+    - php: '7.2'
       env: DB=MYSQL RECIPE_VERSION=4.4.x-dev PHPUNIT_TEST=1
-    - php: 7.3
+    - php: '7.3'
+      env: DB=MYSQL RECIPE_VERSION=4.4.x-dev BEHAT_TEST=1
+    - php: '7.3'
       env: DB=MYSQL RECIPE_VERSION=4.3.x-dev NPM_TEST=1
-    - php: 7.3
+    - php: '7.3'
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
 
 before_script:
+  # Extra $PATH
+  - export PATH=/usr/lib/chromium-browser/:$PATH
+
   # Init PHP
   - phpenv rehash
   - phpenv config-rm xdebug.ini || true
@@ -27,8 +40,15 @@ before_script:
   # Install composer dependencies
   - composer validate
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.1.x-dev --no-update; fi
-  - composer require silverstripe/recipe-cms "$RECIPE_VERSION" --no-update
+  - composer require --no-update silverstripe/recipe-cms:"$RECIPE_VERSION" silverstripe/recipe-testing:^1
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+
+  # Behat bootstrapping
+  - if [[ $BEHAT_TEST ]]; then mkdir artifacts; fi
+  - if [[ $BEHAT_TEST ]]; then cp composer.lock artifacts/; fi
+  - if [[ $BEHAT_TEST ]]; then sh -e /etc/init.d/xvfb start; sleep 3; fi
+  - if [[ $BEHAT_TEST ]]; then (chromedriver > artifacts/chromedriver.log 2>&1 &); fi
+  - if [[ $BEHAT_TEST ]]; then (vendor/bin/serve --bootstrap-file vendor/silverstripe/cms/tests/behat/serve-bootstrap.php &> artifacts/serve.log &); fi
 
   # Install NPM dependencies
   - if [[ $NPM_TEST ]]; then nvm install $TRAVIS_NODE_VERSION && nvm use $TRAVIS_NODE_VERSION && npm install -g yarn && yarn install --network-concurrency 1 && yarn run build; fi
@@ -41,7 +61,11 @@ script:
   - if [[ $NPM_TEST ]]; then git diff --name-status --relative=client; fi
   - if [[ $NPM_TEST ]]; then yarn run coverage; fi
   - if [[ $NPM_TEST ]]; then yarn run lint; fi
+  - if [[ $BEHAT_TEST ]]; then vendor/bin/behat @mfa; fi
 
 after_success:
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml -F php; fi
   - if [[ $NPM_TEST ]]; then bash <(curl -s https://codecov.io/bash) -F js; fi
+
+after_failure:
+  - if [[ $BEHAT_TEST ]]; then php ./vendor/silverstripe/framework/tests/behat/travis-upload-artifacts.php --if-env BEHAT_TEST,ARTIFACTS_BUCKET,ARTIFACTS_KEY,ARTIFACTS_SECRET --target-path $TRAVIS_REPO_SLUG/$TRAVIS_BUILD_ID/$TRAVIS_JOB_ID --artifacts-base-url https://s3.amazonaws.com/$ARTIFACTS_BUCKET/ --artifacts-path ./artifacts/; fi

--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,31 @@
+# Run mfa behat tests with this command
+# Note that mfa behat tests require CMS module
+# ========================================================================= #
+# chromedriver
+# vendor/bin/behat @mfa
+# ========================================================================= #
+default:
+  suites:
+    mfa:
+      paths:
+        - %paths.modules.mfa%/tests/Behat/features
+      contexts:
+        - SilverStripe\Framework\Tests\Behaviour\FeatureContext
+        - SilverStripe\Framework\Tests\Behaviour\CmsFormsContext
+        - SilverStripe\Framework\Tests\Behaviour\CmsUiContext
+        - SilverStripe\BehatExtension\Context\BasicContext
+        - SilverStripe\BehatExtension\Context\EmailContext
+        - SilverStripe\MFA\Tests\Behat\Context\LoginContext
+        - SilverStripe\CMS\Tests\Behaviour\ThemeContext
+  extensions:
+    SilverStripe\BehatExtension\MinkExtension:
+      default_session: facebook_web_driver
+      javascript_session: facebook_web_driver
+      facebook_web_driver:
+        browser: chrome
+        wd_host: "http://127.0.0.1:9515" #chromedriver port
+      browser_name: chrome
+    SilverStripe\BehatExtension\Extension:
+      bootstrap_file: vendor/silverstripe/cms/tests/behat/serve-bootstrap.php
+      screenshot_path: %paths.base%/artifacts/screenshots
+      retry_seconds: 4 # default is 2

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
     "autoload": {
         "psr-4": {
             "SilverStripe\\MFA\\": "src/",
-            "SilverStripe\\MFA\\Tests\\": "tests/php/"
+            "SilverStripe\\MFA\\Tests\\": "tests/php/",
+            "SilverStripe\\MFA\\Tests\\Behat\\": "tests/Behat/"
         }
     },
     "support": {

--- a/tests/Behat/Context/LoginContext.php
+++ b/tests/Behat/Context/LoginContext.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\MFA\Tests\Behat\Context;
+
+use SilverStripe\CMS\Tests\Behaviour\LoginContext as CMSLoginContext;
+use SilverStripe\MFA\Extension\SiteConfigExtension;
+use SilverStripe\SiteConfig\SiteConfig;
+
+/**
+ * Overridden from the CMS module to ensure that MFA can be handled during fixtured member generation
+ */
+class LoginContext extends CMSLoginContext
+{
+    public function iAmLoggedInWithPermissions($permCode)
+    {
+        // Set MFA to optional, perform login logic, then skip MFA
+        $this->multiFactorAuthenticationIsOptional();
+        parent::iAmLoggedInWithPermissions($permCode);
+
+        // Wait for MFA to load
+        $this->getMainContext()->getSession()
+            ->wait(5000, 'document.getElementsByClassName("mfa-app-title").length === 1');
+
+        $this->getMainContext()->pressButton('Setup later');
+    }
+
+    /**
+     * @Given multi factor authentication is optional
+     */
+    public function multiFactorAuthenticationIsOptional()
+    {
+        /** @var SiteConfig&SiteConfigExtension $siteConfig */
+        $siteConfig = SiteConfig::current_site_config();
+        assertNotNull($siteConfig, 'Current SiteConfig record could not be found!');
+
+        $siteConfig->MFARequired = false;
+        $siteConfig->write();
+    }
+
+    /**
+     * @When I select :option from the MFA settings
+     */
+    public function iSelectFromTheMfaSettings($option)
+    {
+        $value = $option === 'MFA is required for everyone' ? 1 : 0;
+        $this->getMainContext()->selectOption('MFARequired', $value);
+    }
+}

--- a/tests/Behat/features/mfa-enabled.feature
+++ b/tests/Behat/features/mfa-enabled.feature
@@ -1,0 +1,17 @@
+Feature: MFA is enabled for the site
+  As a website owner
+  I want to enable multi-factor authentication for my site
+  So that my site will be more secure
+
+  Background:
+    Given I am logged in with "ADMIN" permissions
+    And I go to "/admin"
+    Then I should see the CMS
+
+  Scenario: I can set MFA to be required
+    Given I go to "/admin/settings"
+    And I click the "Access" CMS tab
+    Then I should see "Multi Factor Authentication (MFA)"
+    When I select "MFA is required for everyone" from the MFA settings
+    And I press "Save"
+    Then I should see "Saved"


### PR DESCRIPTION
We need to override the "I am logged in with X permissions" Behat context step to ensure it skips MFA registration. This is done in a class override, but all other modules with Behat tests that use this (all of them) will fail unless they are aware of MFA. This is a limitation we'll need to keep in mind when implementing CWP kitchen sink-wide Behat test runs.

Resolves #99