### PR TITLE
FIX ensure RegisteredMFAFieldList always has a Member and never "not a Member"

### DIFF
--- a/src/FormField/RegisteredMFAMethodListField.php
+++ b/src/FormField/RegisteredMFAMethodListField.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\MFA\FormField;
 
+use InvalidArgumentException;
 use SilverStripe\Admin\SecurityAdmin;
 use SilverStripe\Forms\FormField;
 use SilverStripe\MFA\Controller\AdminRegistrationController;
@@ -9,10 +10,35 @@ use SilverStripe\MFA\Model\RegisteredMethod;
 use SilverStripe\MFA\Service\MethodRegistry;
 use SilverStripe\MFA\Service\RegisteredMethodManager;
 use SilverStripe\MFA\Service\SchemaGenerator;
+use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 
 class RegisteredMFAMethodListField extends FormField
 {
+    /**
+     * Because {@see setValue()} can do nothing on e.g. form submission, it is of critical importance that this
+     * object is never in existence without a valid Member set as the value - we have set the `$value` parameter as
+     * required, however we still need to ensure that it is a valid value. We do this via type hints, and removing the
+     * optionality of the parameters for this constructor
+     */
+    public function __construct(string $name, ?string $title, Member $value)
+    {
+        return parent::__construct($name, $title, $value);
+    }
+
+    public function setValue($value, $data = null)
+    {
+        // When a form submits, it populates data from POST values.
+        // This field is not really a form field - it is a React JS component that renders interactive controls
+        // for a member to manage their MFA settings. It therefore does not have a value, and `null` is not a valid
+        // instance of Member - this causes a PHP Emeregency error (resulting in a HTTP 500). To this end, only ever
+        // set the value if the value passed in is an instance of Member.
+        if ($value instanceof Member) {
+            $this->value = $value;
+        }
+        return $this;
+    }
+
     public function Field($properties = array())
     {
         return $this->renderWith(self::class);

--- a/templates/SilverStripe/MFA/FormField/RegisteredMFAMethodListField.ss
+++ b/templates/SilverStripe/MFA/FormField/RegisteredMFAMethodListField.ss
@@ -1,5 +1,5 @@
 <div
-    $AttributesHTML
+    $AttributesHTML("value")
     data-field-type="registered-mfa-method-list-field"
     data-schema="$SchemaData.JSON"
 ></div>

--- a/tests/php/FormField/RegisteredMFAMethodListFieldTest.php
+++ b/tests/php/FormField/RegisteredMFAMethodListFieldTest.php
@@ -5,22 +5,46 @@ namespace SilverStripe\MFA\Tests\FormField;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\MFA\FormField\RegisteredMFAMethodListField;
 use SilverStripe\Security\Member;
+use TypeError;
 
 class RegisteredMFAMethodListFieldTest extends SapphireTest
 {
-    protected $usesDatabase = true;
+    protected static $fixture_file = 'RegisteredMFAMethodListFieldTest.yml';
 
     public function testSchemaContainsEndpoints()
     {
         $memberID = $this->logInWithPermission();
         $member = Member::get()->byID($memberID);
 
-        $field = new RegisteredMFAMethodListField('test');
-        $field->setValue($member);
+        $field = new RegisteredMFAMethodListField('test', null, $member);
         $schema = $field->getSchemaDataDefaults();
 
         $this->assertContains('register/', $schema['schema']['endpoints']['register']);
         $this->assertContains('method/{urlSegment}', $schema['schema']['endpoints']['remove']);
         $this->assertContains('method/{urlSegment}/default', $schema['schema']['endpoints']['setDefault']);
+    }
+
+    /**
+     * @expectedException TypeError
+     */
+    public function testConstructorRequiresMemberValue()
+    {
+        new RegisteredMFAMethodListField('test', null, null);
+    }
+
+    public function testSetValueOnlyAcceptsMemberObjects()
+    {
+        $memberID = $this->logInWithPermission();
+        $member = Member::get()->byID($memberID);
+
+        $field = new RegisteredMFAMethodListField('test', null, $member);
+        $this->assertSame($member->ID, $field->Value()->ID);
+
+        $field->setValue(null);
+        $this->assertSame($member->ID, $field->Value()->ID, 'Value should remain unchanged after setting NULL');
+
+        $anotherUser = $this->objFromFixture(Member::class, 'another-user');
+        $field->setValue($anotherUser);
+        $this->assertSame($anotherUser->ID, $field->Value()->ID, 'Value updates when setting a Member');
     }
 }

--- a/tests/php/FormField/RegisteredMFAMethodListFieldTest.yml
+++ b/tests/php/FormField/RegisteredMFAMethodListFieldTest.yml
@@ -1,0 +1,5 @@
+SilverStripe\Security\Member:
+  another-user:
+    FirstName: 'Robert'
+    LastName: 'Tables'
+    Email: 'bobbytables@example.org'


### PR DESCRIPTION
It was found that upon submission of a Member form in the CMS (e.g. to update a password)
there was a 500 server error being returned. The submission is of course attempting to
populate all the form fields with submitted data - the React form field for MFA management
is not a form field in the "accepts user input" sense, it is an interactive component
designed to perform actions directly - thus it has no value. No value means the PHP side
FormField instance is attempted to have `null` set as the value upon submission, which
disagrees strongly with the type hint of `Member`, and caused issues.

As this form field has two valid states - on where editing is possible and the member object
is always equal to `Security::getCurrentUser`, and a read only mode where the member may be any
valid member from the database - which means that simply relying on `Security::getCurrentUser`
would be unreliable, we must both require a member to always be set (via the constructor) and
not accept invalid `setValue` requests - but we cannot throw an exception here because this is
expected behaviour upon a form submission.

Resolves #221 