### PR TITLE
NEW Update backup codes to use 12 lowercase letters

### DIFF
--- a/docs/en/backup-codes.md
+++ b/docs/en/backup-codes.md
@@ -57,8 +57,8 @@ SilverStripe\MFA\Service\BackupCodeGenerator:
 
 ### Adjusting the character sets
 
-By default, backup codes will be generated using upper and lowercase letters and numbers. If you would like to increase
-the entropy of your backup codes by adding special characters, you can do so by adding an extension:
+By default, backup codes will be generated using lowercase letters. If you would like to increase
+the entropy of your backup codes by adding extra character types, you can do so by adding an extension:
 
 ```php
 class BackupCodeGeneratorExtension extends Extension

--- a/src/Service/BackupCodeGenerator.php
+++ b/src/Service/BackupCodeGenerator.php
@@ -30,7 +30,7 @@ class BackupCodeGenerator implements BackupCodeGeneratorInterface
      * @config
      * @var int
      */
-    private static $backup_code_length = 9;
+    private static $backup_code_length = 12;
 
     /**
      * Generates a list of backup codes
@@ -58,11 +58,7 @@ class BackupCodeGenerator implements BackupCodeGeneratorInterface
 
     public function getCharacterSet(): array
     {
-        $characterSet = array_merge(
-            range('a', 'z'),
-            range('A', 'Z'),
-            range(0, 9)
-        );
+        $characterSet = range('a', 'z');
 
         $this->extend('updateCharacterSet', $characterSet);
 

--- a/src/Service/BackupCodeGenerator.php
+++ b/src/Service/BackupCodeGenerator.php
@@ -72,7 +72,7 @@ class BackupCodeGenerator implements BackupCodeGeneratorInterface
      * @param int $codeLength
      * @return string
      */
-    protected function generateCode(array $charset, int $codeLength = 9): string
+    protected function generateCode(array $charset, int $codeLength): string
     {
         $characters = [];
         $numberOfOptions = count($charset);


### PR DESCRIPTION
This keeps the same amount (roughly) of entropy as 9 alphanumeric characters but is friendlier on the humans.

Resolves #230