### PR TITLE
FIX allow return value modification in extension hook for canRemoveMethod check

### DIFF
--- a/src/Service/RegisteredMethodManager.php
+++ b/src/Service/RegisteredMethodManager.php
@@ -130,7 +130,7 @@ class RegisteredMethodManager
             $removable = false;
         }
 
-        $this->extend(__FUNCTION__, $member, $method);
+        $this->extend(__FUNCTION__, $removable, $member, $method);
 
         return $removable;
     }


### PR DESCRIPTION
Previously a method was added to test whether or not a method could be removed from a Member object. An extension hook exists to allow other actions to be checked when this method is called, however extensions could not alter the result of the canRemoveMethod check as was intended because the return value was not passed to the extension calls. Now it can be :)