### PR TITLE
FIX correctly redirect after successful log in

### DIFF
--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -75,6 +75,11 @@ class LoginHandler extends BaseLoginHandler
     protected $logger;
 
     /**
+     * @var string hold the back url for the duration of the request (being in memory) {@see getBackURL}
+     */
+    protected $backURL = null;
+
+    /**
      * Override the parent "doLogin" to insert extra steps into the flow
      *
      * @inheritdoc
@@ -457,6 +462,9 @@ class LoginHandler extends BaseLoginHandler
             return $this->redirect($this->getBackURL() ?: $loginUrl);
         }
 
+        // Store the back URL before clearing the session data
+        $this->backURL = $this->getBackURL();
+
         // Clear the "additional data"
         $request->getSession()->clear(static::SESSION_KEY . '.additionalData');
 
@@ -512,7 +520,9 @@ class LoginHandler extends BaseLoginHandler
     }
 
     /**
-     * Adds another option for the back URL to be returned from a current MFA session store
+     * Adds more options for the back URL - to be returned from a current MFA session store or from memory during this
+     * request. The latter is required as session store is cleared before the 'BackURL' key is utilised
+     * {@see redirectAfterSuccessfulLogin}
      *
      * @return string|null
      */
@@ -527,7 +537,7 @@ class LoginHandler extends BaseLoginHandler
             }
         }
 
-        return $backURL;
+        return $backURL ?: $this->backURL;
     }
 
     /**

--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -458,6 +458,7 @@ class LoginHandler extends BaseLoginHandler
         }
 
         // Redirecting after successful login expects a getVar to be set, store it before clearing the session data
+        /** @see HTTPRequest::offsetSet */
         $request['BackURL'] = $this->getBackURL();
 
         // Clear the "additional data"
@@ -515,9 +516,7 @@ class LoginHandler extends BaseLoginHandler
     }
 
     /**
-     * Adds more options for the back URL - to be returned from a current MFA session store or from memory during this
-     * request. The latter is required as session store is cleared before the 'BackURL' key is utilised
-     * {@see redirectAfterSuccessfulLogin}
+     * Adds more options for the back URL - to be returned from a current MFA session store
      *
      * @return string|null
      */

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\MFA\Tests\Authenticator;
 
+use Page;
 use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
@@ -232,22 +233,75 @@ class LoginHandlerTest extends FunctionalTest
         ];
     }
 
-    public function testSkipRegistration()
+    /**
+     * @param $memberFixture
+     * @param $expectedRedirect
+     * @dataProvider skipRegistrationProvider
+     */
+    public function testSkipRegistration($memberFixture, $mfaRequiredInGrace = false, $expectedRedirect = null)
     {
-        $this->setSiteConfig(['MFARequired' => false]);
+        if ($mfaRequiredInGrace) {
+            $this->setSiteConfig([
+                'MFARequired' => true,
+                'MFAGracePeriodExpires' => DBDatetime::now()
+                    ->setValue(strtotime('+1 day', DBDatetime::now()->getTimestamp()))->Rfc2822()
+            ]);
+        } else {
+            $this->setSiteConfig(['MFARequired' => false]);
+        }
 
-        $member = new Member();
-        $member->FirstName = 'Some new';
-        $member->Surname = 'member';
-        $memberId = $member->write();
-        $this->logInAs($member);
+        if (!$expectedRedirect) {
+            $expectedRedirect = Controller::join_links(Security::login_url(), 'default');
+        }
 
+        /** @var Member $member */
+        $member = $this->objFromFixture(Member::class, $memberFixture);
+        $this->scaffoldPartialLogin($member);
+
+        $this->autoFollowRedirection = false;
         $response = $this->get(Controller::join_links(Security::login_url(), 'default/mfa/skip'));
 
-        $this->assertSame(200, $response->getStatusCode());
+        // Assert a redirect is given
+        $this->assertSame(302, $response->getStatusCode());
 
-        $member = Member::get()->byID($memberId);
+        // Assert the redirect is to the expected location
+        $this->assertStringEndsWith($expectedRedirect, $response->getHeader('location'));
+
+        // Assert the user is now logged in
+        $this->assertSame($member->ID, Security::getCurrentUser()->ID, 'User is successfully logged in');
+
+        // Assert that the member is tracked as having skipped registration
+        $member = Member::get()->byID($member->ID);
         $this->assertTrue((bool)$member->HasSkippedMFARegistration);
+    }
+
+    public function skipRegistrationProvider()
+    {
+        return [
+            ['guy'],
+            ['guy', true],
+            ['pete', false, 'Security/changepassword'],
+            ['pete', true, 'Security/changepassword'],
+        ];
+    }
+
+    /**
+     * @param $memberFixture
+     * @dataProvider methodlessMemberFixtureProvider
+     */
+    public function testBackURLIsPreservedWhenSkipping($memberFixture)
+    {
+        /** @var Member $member */
+        $member = $this->objFromFixture(Member::class, $memberFixture);
+        $this->scaffoldPartialLogin($member);
+
+        $this->doLogin($member, 'Password123', 'admin/pages');
+
+        $this->autoFollowRedirection = false;
+        $response = $this->get(Controller::join_links(Security::login_url(), 'default/mfa/skip'));
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertStringEndsWith('admin/pages', $response->getHeader('location'));
     }
 
     /**
@@ -431,6 +485,43 @@ class LoginHandlerTest extends FunctionalTest
         $this->assertSame($failedLogins + 1, $member->FailedLoginCount, 'Failed login is registered');
     }
 
+    /**
+     * @param $memberFixture
+     * @dataProvider methodlessMemberFixtureProvider
+     */
+    public function testFinishVerificationWillRedirectToTheBackURLSetAsLoginIsStarted($memberFixture)
+    {
+        /** @var Member $member */
+        $member = $this->objFromFixture(Member::class, $memberFixture);
+        $this->scaffoldPartialLogin($member);
+
+        $this->doLogin($member, 'Password123', 'admin/pages');
+
+        /** @var LoginHandler|PHPUnit_Framework_MockObject_MockObject $handler */
+        $handler = $this->getMockBuilder(LoginHandler::class)
+            ->setMethods(['completeVerificationRequest'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $handler->expects($this->once())->method('completeVerificationRequest')->willReturn(Result::create());
+
+        $request = new HTTPRequest('GET', '/');
+        $request->setSession(new Session([]));
+        $store = new SessionStore($member);
+        $store->setMethod('basic-math');
+        $handler->setStore($store);
+
+        $response = $handler->finishVerification($request);
+
+        // Assert "Accepted" response
+        $this->assertSame(202, $response->getStatusCode());
+
+        $this->autoFollowRedirection = false;
+        $response = $this->get(Controller::join_links(Security::login_url(), 'default/mfa/complete'));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertStringEndsWith('admin/pages', $response->getHeader('location'));
+    }
+
     public function testGetBackURL()
     {
         $handler = new LoginHandler('foo', $this->createMock(MemberAuthenticator::class));
@@ -444,6 +535,11 @@ class LoginHandlerTest extends FunctionalTest
         $session->set(LoginHandler::SESSION_KEY . '.additionalData', ['BackURL' => 'foobar']);
 
         $this->assertSame('foobar', $handler->getBackURL());
+    }
+
+    public function methodlessMemberFixtureProvider()
+    {
+        return [['guy', 'carla']];
     }
 
     /**
@@ -463,9 +559,15 @@ class LoginHandlerTest extends FunctionalTest
      * @param string $password
      * @return HTTPResponse
      */
-    protected function doLogin(Member $member, $password)
+    protected function doLogin(Member $member, $password, $backUrl = null)
     {
-        $this->get(Config::inst()->get(Security::class, 'login_url'));
+        $url = Config::inst()->get(Security::class, 'login_url');
+
+        if ($backUrl) {
+            $url .= '?BackURL=' . $backUrl;
+        }
+
+        $this->get($url);
 
         return $this->submitForm(
             'MemberLoginForm_LoginForm',

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\MFA\Tests\Authenticator;
 
-use Page;
 use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
@@ -234,8 +233,9 @@ class LoginHandlerTest extends FunctionalTest
     }
 
     /**
-     * @param $memberFixture
-     * @param $expectedRedirect
+     * @param string $memberFixture
+     * @param bool $mfaRequiredInGrace
+     * @param string|null $expectedRedirect
      * @dataProvider skipRegistrationProvider
      */
     public function testSkipRegistration($memberFixture, $mfaRequiredInGrace = false, $expectedRedirect = null)
@@ -286,7 +286,7 @@ class LoginHandlerTest extends FunctionalTest
     }
 
     /**
-     * @param $memberFixture
+     * @param string $memberFixture
      * @dataProvider methodlessMemberFixtureProvider
      */
     public function testBackURLIsPreservedWhenSkipping($memberFixture)
@@ -486,7 +486,7 @@ class LoginHandlerTest extends FunctionalTest
     }
 
     /**
-     * @param $memberFixture
+     * @param string $memberFixture
      * @dataProvider methodlessMemberFixtureProvider
      */
     public function testFinishVerificationWillRedirectToTheBackURLSetAsLoginIsStarted($memberFixture)
@@ -572,12 +572,12 @@ class LoginHandlerTest extends FunctionalTest
         return $this->submitForm(
             'MemberLoginForm_LoginForm',
             null,
-            array(
+            [
                 'Email' => $member->Email,
                 'Password' => $password,
                 'AuthenticationMethod' => MemberAuthenticator::class,
                 'action_doLogin' => 1,
-            )
+            ]
         );
     }
 

--- a/tests/php/Authenticator/LoginHandlerTest.yml
+++ b/tests/php/Authenticator/LoginHandlerTest.yml
@@ -3,16 +3,25 @@ SilverStripe\MFA\Model\RegisteredMethod:
     MethodClassName: "SilverStripe\\MFA\\Tests\\Stub\\BasicMath\\Method"
   robbie-math:
     MethodClassName: "SilverStripe\\MFA\\Tests\\Stub\\BasicMath\\Method"
+  colin-math:
+    MethodClassName: "SilverStripe\\MFA\\Tests\\Stub\\BasicMath\\Method"
+
 
 SilverStripe\Security\Permission:
   admin:
     Code: ADMIN
+  content:
+    Code: CMS_ACCESS_CMSMain
 
 SilverStripe\Security\Group:
   admingroup:
     Title: Create, edit and delete pages
     Code: admingroup
     Permissions: =>SilverStripe\Security\Permission.admin
+  contentgroup:
+    Title: Content author
+    Code: contentgroup
+    Permissions: =>SilverStripe\Security\Permission.content
 
 SilverStripe\Security\Member:
   guy:
@@ -29,4 +38,15 @@ SilverStripe\Security\Member:
     RegisteredMFAMethods: =>SilverStripe\MFA\Model\RegisteredMethod.robbie-math
     DefaultRegisteredMethodID: =>SilverStripe\MFA\Model\RegisteredMethod.robbie-math
     Groups: =>SilverStripe\Security\Group.admingroup
-
+  colin:
+    Email: colin@example.com
+    RegisteredMFAMethods: =>SilverStripe\MFA\Model\RegisteredMethod.colin-math
+    DefaultRegisteredMethodID: =>SilverStripe\MFA\Model\RegisteredMethod.colin-math
+    Groups: =>SilverStripe\Security\Group.contentgroup
+  carla:
+    Email: carla@example.com
+    Groups: =>SilverStripe\Security\Group.contentgroup
+  pete:
+    Email: pete@example.com
+    PasswordExpiry: 1990-01-01
+    Groups: =>SilverStripe\Security\Group.contentgroup


### PR DESCRIPTION
The usage of the BackURL key in the request does not work with MFA as it operates over many reqeusts, interrupting the 'normal' operation (default member authenticator logic).
MFA gets around this by storing the BackURL value in the session tied to the request - but this was being (correctly) cleared before the redirect is performed after a successful log in.
This commit fixes this by making a short lived store in memory for this value, and is still able to be utilised by the redirect logic from the 'normal' operation.

Resolves #250