### PR TITLE
FIX Ignore project defined password strength rules in MFA unit tests

### DIFF
--- a/tests/php/Extension/AccountReset/SecurityExtensionTest.php
+++ b/tests/php/Extension/AccountReset/SecurityExtensionTest.php
@@ -18,6 +18,19 @@ class SecurityExtensionTest extends FunctionalTest
 {
     protected static $fixture_file = 'SecurityExtensionTest.yml';
 
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $validator = Member::password_validator();
+        // Do not let project code rules for password strength break these tests
+        if ($validator) {
+            $validator
+                ->setMinLength(6)
+                ->setMinTestScore(1);
+        }
+    }
+
     public function testResetAccountFailsWhenAlreadyAuthenticated()
     {
         /** @var Member&MemberExtension $member */


### PR DESCRIPTION
Was causing a test failure from global state in CWP. See https://github.com/silverstripe/cwp-recipe-kitchen-sink/issues/33.