### PR TITLE
FIX Email correct content via translation key correction

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -32,7 +32,8 @@ en:
     CODESLEFT: 'You now have {count} codes remaining.'
     HELLO: Hi
     NOTYOU: 'If you did not take this action, please contact your system administrator immediately.'
-    REGISTERED: 'You have removed the {method} authentication method from your account at {site}.'
+    REGISTERED: 'You have successfully registered {method} as an extra layer of protection for your account at {site}.'
+    REMOVED: 'You have removed the {method} authentication method from your account at {site}.'
     USEDBACKUPCODE: 'A recovery code was used to gain access to your account at {site}.'
   SilverStripe\MFA\Extension\AccountReset\SecurityAdminExtension:
     ACCOUNT_RESET_EMAIL_SUBJECT: 'Reset your account'

--- a/templates/SilverStripe/MFA/Email/Notification_removed.ss
+++ b/templates/SilverStripe/MFA/Email/Notification_removed.ss
@@ -1,7 +1,7 @@
 <p><%t SilverStripe\\MFA\\Email\\Notification.HELLO 'Hi' %> $Member.Name,</p>
 
 <p>
-	<%t SilverStripe\\MFA\\Email\\Notification.REGISTERED 'You have removed the {method} authentication method from your account at {site}.' method=$MethodName site=$AbsoluteBaseURL %>
+	<%t SilverStripe\\MFA\\Email\\Notification.REMOVED 'You have removed the {method} authentication method from your account at {site}.' method=$MethodName site=$AbsoluteBaseURL %>
 </p>
 
 <p>

--- a/tests/Behat/Context/LoginContext.php
+++ b/tests/Behat/Context/LoginContext.php
@@ -7,7 +7,7 @@ use SilverStripe\BehatExtension\Context\LoginContext as BehatLoginContext;
 use SilverStripe\MFA\Extension\SiteConfigExtension;
 use SilverStripe\SiteConfig\SiteConfig;
 
-if (!class_exists(CMSLoginContext::class) || !class_exists(BehatLoginContext::class)) {
+if (!class_exists(BehatLoginContext::class) || !class_exists(CMSLoginContext::class)) {
     return;
 }
 

--- a/tests/php/Service/RegisteredMethodManagerTest.php
+++ b/tests/php/Service/RegisteredMethodManagerTest.php
@@ -14,6 +14,7 @@ use SilverStripe\MFA\Service\RegisteredMethodManager;
 use SilverStripe\MFA\Tests\Stub\BasicMath\Method as BasicMathMethod;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
+use SilverStripe\View\SSViewer;
 
 class RegisteredMethodManagerTest extends SapphireTest
 {
@@ -92,6 +93,7 @@ class RegisteredMethodManagerTest extends SapphireTest
 
     public function testRegisterForMemberSendsNotification()
     {
+        SSViewer::set_themes(['$public', '$default']);
         /** @var Member&MemberExtension $member */
         $member = Member::create(['FirstName' => 'Mike', 'Email' => 'test@example.com']);
         $member->write();
@@ -100,7 +102,12 @@ class RegisteredMethodManagerTest extends SapphireTest
         $manager = RegisteredMethodManager::singleton();
         RegisteredMethodManager::singleton()->registerForMember($member, $method, ['foo', 'bar']);
 
-        $this->assertEmailSent($member->Email, null, '/method was added to your account/');
+        $this->assertEmailSent(
+            $member->Email,
+            null,
+            '/method was added to your account/',
+            '/You have successfully registered/'
+        );
     }
 
     public function testRegisterBackupMethodDoesNotSendEmail()
@@ -146,13 +153,14 @@ class RegisteredMethodManagerTest extends SapphireTest
 
     public function testDeleteFromMemberSendsNotification()
     {
+        SSViewer::set_themes(['$public', '$default']);
         /** @var Member&MemberExtension $member */
         $member = $this->objFromFixture(Member::class, 'bob_jones');
 
         $manager = RegisteredMethodManager::singleton();
         $manager->deleteFromMember($member, new BasicMathMethod());
 
-        $this->assertEmailSent($member->Email, null, '/method was removed from your account/');
+        $this->assertEmailSent($member->Email, null, '/method was removed from your account/', '/You have removed/');
     }
 
     public function testDeletingLastMethodRemovesBackupCodes()


### PR DESCRIPTION
Upon registering a user is being sent an email to notify them that they have successfully added a multiple factor of authentication to their account on the site.
However due to a mix up with translation keys, the default text was being replaced with that for removing an authentication factor.
This commit fixes the translation key, and extends the tests to cover the body as well as the subject.

resolves #259 