### PR TITLE
FIX Defer member access for performance and cases where DB is not available on session start

### DIFF
--- a/tests/php/Store/SessionStoreTest.php
+++ b/tests/php/Store/SessionStoreTest.php
@@ -4,6 +4,8 @@ namespace SilverStripe\MFA\Tests\Store;
 
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\MFA\Store\SessionStore;
+use SilverStripe\ORM\Connect\Database;
+use SilverStripe\ORM\DB;
 use SilverStripe\Security\Member;
 
 class SessionStoreTest extends SapphireTest
@@ -77,5 +79,31 @@ class SessionStoreTest extends SapphireTest
         $store->setMember($member2);
 
         $this->assertEmpty($store->getMethod());
+    }
+
+    public function testDatabaseIsNotAccessedOnDeserialise()
+    {
+        // Create a store
+        $member = new Member();
+        $member->ID = 1;
+        $store = new SessionStore($member);
+        $serialised = $store->serialize();
+
+        // Replace the DB connection with a mock
+        $connection = DB::get_conn();
+        $database = $this->getMockBuilder(Database::class)
+            ->enableProxyingToOriginalMethods()
+            ->setProxyTarget($connection)
+            ->getMock();
+
+        $database->expects($this->never())->method('query');
+        $database->expects($this->never())->method('preparedQuery');
+        DB::set_conn($database);
+
+        // Replicate the deserialisation that happens on session start
+        $store->unserialize($serialised);
+
+        // Finish the test and allow mock assertions to fail the test
+        DB::set_conn($connection);
     }
 }


### PR DESCRIPTION
Fixes #274 (but needs a backport). I think @indygriffiths confirmed this locally