### PR TITLE
Prevent methods from being registered more than once

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,17 +28,22 @@ You should also install one of the additional multi-factor authenticator modules
 
 After installing this module _and_ a supported factor method module (e.g. TOTP), the default member authenticator
 will be replaced with the MFA authenticator instead. This will provide no change in the steps taken to log in until
-an MFA Method has also been configured for the site:
+an MFA Method has also been configured for the site. The TOTP and WebAuthn modules will configure themselves
+automatically.
+
+After installing the MFA module and having at least one method configured, MFA will automatically be enabled. By default
+it will be optional (users can skip MFA registration). You can make it mandatory via the Settings tab in the admin area.
+
+### Configuring custom methods
+
+If you have built your own MFA method, you can register it with the `MethodRegistry` to enable it:
 
 ```yaml
 SilverStripe\MFA\Service\MethodRegistry:
   methods:
-    - MyMethod
-    - Another\Method\Here
+    - MyCustomMethod
+    - Another\Custom\Method\Here
 ```
-
-After installing, an option in site configuration will enable MFA for users, which will automatically be added after
-login and to member profiles.
 
 ## Documentation
 

--- a/src/Service/MethodRegistry.php
+++ b/src/Service/MethodRegistry.php
@@ -48,6 +48,8 @@ class MethodRegistry
      *
      * @return MethodInterface[]
      * @throws UnexpectedValueException When an invalid method is registered
+     * @throws UnexpectedValueException If a method was registered more than once
+     * @throws UnexpectedValueException If multiple registered methods share a common URL segment
      */
     public function getMethods(): array
     {
@@ -57,9 +59,9 @@ class MethodRegistry
 
         $configuredMethods = (array) $this->config()->get('methods');
         $configuredMethods = array_filter($configuredMethods);
+        $this->ensureNoDuplicateMethods($configuredMethods);
 
         $allMethods = [];
-
         foreach ($configuredMethods as $method) {
             $method = Injector::inst()->get($method);
 
@@ -73,6 +75,7 @@ class MethodRegistry
 
             $allMethods[] = $method;
         }
+        $this->ensureNoDuplicateURLSegments($allMethods);
 
         return $this->methodInstances = $allMethods;
     }
@@ -130,5 +133,52 @@ class MethodRegistry
         }
 
         return null;
+    }
+
+    /**
+     * Ensure that attempts to register a method multiple times do not occur
+     *
+     * @param array $configuredMethods
+     * @throws UnexpectedValueException
+     */
+    private function ensureNoDuplicateMethods(array $configuredMethods): void
+    {
+        $uniqueMethods = array_unique($configuredMethods);
+        if ($uniqueMethods === $configuredMethods) {
+            return;
+        }
+
+        // Get the method class names that were added more than once and format them into a string so we can
+        // tell the developer which classes were incorrectly configured
+        $duplicates = array_unique(array_diff_key($configuredMethods, $uniqueMethods));
+        $methodNames = implode('; ', $duplicates);
+        throw new UnexpectedValueException(
+            'Cannot register MFA methods more than once. Check your config: ' . $methodNames
+        );
+    }
+
+    /**
+     * Ensure that all registered methods have a unique URLSegment
+     *
+     * @param array $allMethods
+     * @throws UnexpectedValueException
+     */
+    private function ensureNoDuplicateURLSegments(array $allMethods): void
+    {
+        $allURLSegments = array_map(function (MethodInterface $method) {
+            return $method->getURLSegment();
+        }, $allMethods);
+        $uniqueURLSegments = array_unique($allURLSegments);
+        if ($allURLSegments === $uniqueURLSegments) {
+            return;
+        }
+
+        // Get the method URL segments that were added more than once and format them into a string so we can
+        // tell the developer which classes were incorrectly configured
+        $duplicates = array_unique(array_diff_key($allURLSegments, $uniqueURLSegments));
+        $urlSegments = implode('; ', $duplicates);
+        throw new UnexpectedValueException(
+            'Cannot register multiple MFA methods with the same URL segment: ' . $urlSegments
+        );
     }
 }

--- a/tests/php/Service/MethodRegistryTest.php
+++ b/tests/php/Service/MethodRegistryTest.php
@@ -6,6 +6,7 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\MFA\Service\MethodRegistry;
 use SilverStripe\MFA\Tests\Stub\BasicMath\Method;
+use SilverStripe\MFA\Tests\Stub\DuplicatedBasicMath;
 use SilverStripe\Security\Member;
 use UnexpectedValueException;
 
@@ -22,8 +23,8 @@ class MethodRegistryTest extends SapphireTest
     }
 
     /**
-     * phpcs:disable
      * @expectedException UnexpectedValueException
+     * phpcs:disable
      * @expectedExceptionMessage Given method "SilverStripe\Security\Member" does not implement SilverStripe\MFA\Method\MethodInterface
      * phpcs:enable
      */
@@ -32,5 +33,36 @@ class MethodRegistryTest extends SapphireTest
         Config::modify()->set(MethodRegistry::class, 'methods', [Member::class]);
         $registry = MethodRegistry::singleton();
         $registry->getMethods();
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     * phpcs:disable
+     * @expectedExceptionMessage Cannot register MFA methods more than once. Check your config: SilverStripe\MFA\Tests\Stub\BasicMath\Method
+     * phpcs:enable
+     */
+    public function testRegisteringMethodMultipleTimesThrowsException()
+    {
+        Config::modify()->set(MethodRegistry::class, 'methods', [
+            Method::class,
+            Method::class,
+            Method::class,
+        ]);
+
+        MethodRegistry::singleton()->getMethods();
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     * @expectedExceptionMessage Cannot register multiple MFA methods with the same URL segment: basic-math
+     */
+    public function testRegisteringMethodsWithSameURLSegmentThrowsException()
+    {
+        Config::modify()->set(MethodRegistry::class, 'methods', [
+            Method::class,
+            DuplicatedBasicMath\Method::class,
+        ]);
+
+        MethodRegistry::singleton()->getMethods();
     }
 }

--- a/tests/php/Stub/BasicMath/Method.php
+++ b/tests/php/Stub/BasicMath/Method.php
@@ -4,11 +4,9 @@ namespace SilverStripe\MFA\Tests\Stub\BasicMath;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Dev\TestOnly;
-use SilverStripe\MFA\Method\Handler\VerifyHandlerInterface;
 use SilverStripe\MFA\Method\Handler\RegisterHandlerInterface;
+use SilverStripe\MFA\Method\Handler\VerifyHandlerInterface;
 use SilverStripe\MFA\Method\MethodInterface;
-use SilverStripe\MFA\State\AvailableMethodDetails;
-use SilverStripe\MFA\State\AvailableMethodDetailsInterface;
 
 class Method implements MethodInterface, TestOnly
 {

--- a/tests/php/Stub/DuplicatedBasicMath/Method.php
+++ b/tests/php/Stub/DuplicatedBasicMath/Method.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\Stub\DuplicatedBasicMath;
+
+use SilverStripe\MFA\Tests\Stub\BasicMath\Method as BasicMathMethod;
+
+/**
+ * Used to test conflict resolution between methods in the registry
+ */
+class Method extends BasicMathMethod
+{
+
+}


### PR DESCRIPTION
* Docs update to clarify in readme
* MethodRegistry throws an exception if you register more than one method

Resolves #258