### PR TITLE
API RegisteredMFAMethodListField now expects a Member ID int as its value

### DIFF
--- a/src/Extension/MemberExtension.php
+++ b/src/Extension/MemberExtension.php
@@ -78,7 +78,7 @@ class MemberExtension extends DataExtension implements PermissionProvider
             $methodListField = RegisteredMFAMethodListField::create(
                 'MFASettings',
                 _t(__CLASS__ . '.MFA_SETTINGS_FIELD_LABEL', 'Multi-factor authentication settings (MFA)'),
-                $this->owner
+                $this->owner->ID
             )
         );
 

--- a/src/FormField/RegisteredMFAMethodListField.php
+++ b/src/FormField/RegisteredMFAMethodListField.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\MFA\FormField;
 
+use DataObject;
 use FormField;
 use Member;
 use MFARegisteredMethod as RegisteredMethod;
@@ -39,7 +40,7 @@ class RegisteredMFAMethodListField extends FormField
         $adminController = AdminRegistrationController::singleton();
         $generator = SchemaGenerator::create();
         /** @var Member $member */
-        $member = Member::get()->byID($this->value);
+        $member = DataObject::get_by_id(Member::class, $this->value);
 
         return json_encode([
             'schema' => $generator->getSchema($member) + [

--- a/src/FormField/RegisteredMFAMethodListField.php
+++ b/src/FormField/RegisteredMFAMethodListField.php
@@ -15,27 +15,15 @@ use SilverStripe\MFA\Service\SchemaGenerator;
 class RegisteredMFAMethodListField extends FormField
 {
     /**
-     * Because {@see setValue()} can do nothing on e.g. form submission, it is of critical importance that this
-     * object is never in existence without a valid Member set as the value - we have set the `$value` parameter as
-     * required, however we still need to ensure that it is a valid value. We do this via type hints, and removing the
-     * optionality of the parameters for this constructor
+     * {@inheritDoc}
+     *
+     * @param string      $name  Field name
+     * @param string|null $title Field title
+     * @param int         $value Member ID to apply this field to
      */
-    public function __construct(string $name, ?string $title, Member $value)
+    public function __construct(string $name, ?string $title, int $value)
     {
         parent::__construct($name, $title, $value);
-    }
-
-    public function setValue($value, $data = null)
-    {
-        // When a form submits, it populates data from POST values.
-        // This field is not really a form field - it is a React JS component that renders interactive controls
-        // for a member to manage their MFA settings. It therefore does not have a value, and `null` is not a valid
-        // instance of Member - this causes a PHP Emeregency error (resulting in a HTTP 500). To this end, only ever
-        // set the value if the value passed in is an instance of Member.
-        if ($value instanceof Member) {
-            $this->value = $value;
-        }
-        return $this;
     }
 
     public function Field($properties = array())
@@ -44,15 +32,17 @@ class RegisteredMFAMethodListField extends FormField
     }
 
     /**
-     * @return array
+     * @return string
      */
     public function getSchemaData()
     {
         $adminController = AdminRegistrationController::singleton();
         $generator = SchemaGenerator::create();
+        /** @var Member $member */
+        $member = Member::get()->byID($this->value);
 
         return json_encode([
-            'schema' => $generator->getSchema($this->value) + [
+            'schema' => $generator->getSchema($member) + [
                 'endpoints' => [
                     'register' => $adminController->Link('register/{urlSegment}'),
                     'remove' => $adminController->Link('method/{urlSegment}'),
@@ -63,7 +53,7 @@ class RegisteredMFAMethodListField extends FormField
                 'backupCreationDate' => $this->getBackupMethod()
                     ? $this->getBackupMethod()->Created
                     : null,
-                'resetEndpoint' => SecurityAdmin::singleton()->Link("reset/{$this->value->ID}"),
+                'resetEndpoint' => SecurityAdmin::singleton()->Link("reset/{$this->value}"),
                 'isMFARequired' => EnforcementManager::create()->isMFARequired(),
             ],
             'readOnly' => $this->isReadonly(),

--- a/tests/php/FormField/RegisteredMFAMethodListFieldTest.php
+++ b/tests/php/FormField/RegisteredMFAMethodListFieldTest.php
@@ -4,7 +4,6 @@ namespace SilverStripe\MFA\Tests\FormField;
 
 use SapphireTest;
 use SilverStripe\MFA\FormField\RegisteredMFAMethodListField;
-use Member;
 use TypeError;
 
 class RegisteredMFAMethodListFieldTest extends SapphireTest
@@ -14,9 +13,8 @@ class RegisteredMFAMethodListFieldTest extends SapphireTest
     public function testSchemaContainsEndpoints()
     {
         $memberID = $this->logInWithPermission();
-        $member = Member::get()->byID($memberID);
 
-        $field = new RegisteredMFAMethodListField('test', null, $member);
+        $field = new RegisteredMFAMethodListField('test', null, $memberID);
         $schema = json_decode($field->getSchemaData(), true);
 
         $this->assertContains('register/', $schema['schema']['endpoints']['register']);
@@ -30,21 +28,5 @@ class RegisteredMFAMethodListFieldTest extends SapphireTest
     public function testConstructorRequiresMemberValue()
     {
         new RegisteredMFAMethodListField('test', null, null);
-    }
-
-    public function testSetValueOnlyAcceptsMemberObjects()
-    {
-        $memberID = $this->logInWithPermission();
-        $member = Member::get()->byID($memberID);
-
-        $field = new RegisteredMFAMethodListField('test', null, $member);
-        $this->assertSame($member->ID, $field->Value()->ID);
-
-        $field->setValue(null);
-        $this->assertSame($member->ID, $field->Value()->ID, 'Value should remain unchanged after setting NULL');
-
-        $anotherUser = $this->objFromFixture(Member::class, 'another-user');
-        $field->setValue($anotherUser);
-        $this->assertSame($anotherUser->ID, $field->Value()->ID, 'Value updates when setting a Member');
     }
 }


### PR DESCRIPTION
Using a DataObject as a field's value in SilverStripe 3 does not work, it ends up with infinite recursion while checking for whether the field it represents on the DataObject has been changed.

We don't need the Member object as the field value at all, so this removes some of the workaround code for previous issues with this and uses a member ID as the value instead.

Fixes https://github.com/silverstripe/silverstripe-mfa/issues/275