### PR TITLE
Fix missing method on the Change Password handler endpoints

### DIFF
--- a/src/Extension/ChangePasswordExtension.php
+++ b/src/Extension/ChangePasswordExtension.php
@@ -72,7 +72,7 @@ class ChangePasswordExtension extends Extension
             return $this->jsonResponse(
                 array_merge($schema, [
                     'endpoints' => [
-                        'verify' => $this->owner->Link('mfa/login/{urlSegment}'),
+                        'verify' => $this->owner->Link('changepassword/mfa/login/{urlSegment}'),
                         'complete' => $this->owner->Link('changepassword'),
                     ],
                     'shouldRedirect' => false,

--- a/templates/SilverStripe/MFA/Authenticator/ChangePasswordHandler.ss
+++ b/templates/SilverStripe/MFA/Authenticator/ChangePasswordHandler.ss
@@ -1,1 +1,1 @@
-<div id="mfa-app" class="mfa-app" data-schemaurl="$Link('mfa/schema')"></div>
+<div id="mfa-app" class="mfa-app" data-schemaurl="$Link('changepassword/mfa/schema')"></div>


### PR DESCRIPTION
Both the schema endpoint and endpoint for the authentication method were wrong, resulting in the MFA screen hanging when a user clicks the link of the Password Reset email.

Fixes #297 