### PR TITLE
NEW report to show members who have registered an MFA method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
             "email": "simonerkelens@silverstripe.com"
         },
         {
-            "name": "SilverStripe",
+            "name": "SilverStripe Ltd.",
             "homepage": "https://www.silverstripe.com"
         },
         {

--- a/src/Report/EnabledMembers.php
+++ b/src/Report/EnabledMembers.php
@@ -1,0 +1,222 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\MFA\Report;
+
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\NumericField;
+use SilverStripe\Forms\TextField;
+use SilverStripe\MFA\Extension\MemberExtension;
+use SilverStripe\MFA\Method\MethodInterface;
+use SilverStripe\MFA\Service\MethodRegistry;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\Filterable;
+use SilverStripe\ORM\SS_List;
+use SilverStripe\Reports\Report;
+use SilverStripe\Security\Member;
+use SilverStripe\View\ArrayData;
+
+if (!class_exists(Report::class)) {
+    return;
+}
+
+class EnabledMembers extends Report
+{
+    protected $title = 'Multi-factor authentication status of members';
+
+    protected $description = 'Identifies all members on this site, with columns added to indicate the status each has'
+        . ' in regards to multi-factor authentication method registration.';
+
+    protected $dataClass = Member::class;
+
+    public function title(): string
+    {
+        return _t(__CLASS__ . '.TITLE', parent::title());
+    }
+
+    public function description(): string
+    {
+        return _t(__CLASS__ . '.DESCRIPTION', parent::description());
+    }
+
+    /**
+     * Supplies the list displayed in the report. Required method for {@see Report} to work, but is not inherited API
+     *
+     * @param array $params
+     * @return SS_List
+     */
+    public function sourceRecords($params): SS_List
+    {
+        $methods = $this->getMethodClassToTitleMapping();
+
+        // Any GridFieldAction will submit all form inputs, regardless of whether or not they have valid values.
+        // This results in zero results when no filters have been set, as the query then filters for empty string
+        // on all parameters. `stlen` is a safe function, as all user input comes through to PHP as strings.
+        $params = array_filter($params, 'strlen');
+
+        // Having a WHERE limits the results, which means the the COUNT will be off (GROUP BY applied after WHERE)
+        // So clip the count filter and apply it after the database query, only if Methods filter is also set
+        // this way we can delegate to the database where possible, which should be faster.
+        if (isset($params['Count'])) {
+            $desiredCount = (int)$params['Count'];
+            if (isset($params['Methods'])) {
+                $countFilter = $desiredCount;
+                unset($params['Count']);
+            } elseif ($desiredCount) {
+                // When querying SQL COUNT() - this will always factor in the backup method, which is excluded in the
+                // secondary query below to get the list of method names the user has registered. So to compensate we
+                // need to bump up the entered number by 1.
+                $params['Count'] = $desiredCount + 1;
+            }
+        }
+
+        $filteredList = ArrayList::create([]);
+        $backupClass = $this->getBackupMethodClass();
+        /** @var Member[]&MemberExtension[] $members */
+        $members = $this->applyParams(Member::get(), $params)->toArray();
+        foreach ($members as $member) {
+            $defaultMethod = $member->getDefaultRegisteredMethod();
+            $defaultMethodClassName = $defaultMethod ? $defaultMethod->MethodClassName : '';
+
+            $registeredMethods = $member
+                ->RegisteredMFAMethods()
+                ->exclude('MethodClassName', $backupClass)
+                ->column('MethodClassName');
+            $registeredMethodNames = array_map(function (string $methodClass) use ($methods): string {
+                return $methods[$methodClass];
+            }, $registeredMethods);
+
+            $memberReportData = ArrayData::create();
+            foreach ($member->summaryFields() as $field => $name) {
+                $memberReportData->$field = $member->$field;
+            }
+
+            $memberReportData->methodCount = (string)count($registeredMethods);
+            $memberReportData->registeredMethods = implode(', ', $registeredMethodNames);
+            $memberReportData->defaultMethodName = $methods[$defaultMethodClassName] ?? '';
+            $memberReportData->skippedRegistration = $member->dbObject('HasSkippedMFARegistration')->Nice();
+
+            $filteredList->push($memberReportData);
+        };
+        if (isset($countFilter)) {
+            $filteredList = $filteredList->filter('methodCount', $countFilter);
+        }
+        $this->extend('updateSourceRecords', $filteredList);
+        return $filteredList;
+    }
+
+    /**
+     * List the columns configured to display in the resulting reports GridField
+     *
+     * @return array
+     */
+    public function columns(): array
+    {
+        $columns = singleton(Member::class)->summaryFields() + [
+            'methodCount' => _t(__CLASS__ . '.COLUMN_METHOD_COUNT', '№ methods'),
+            'registeredMethods' => _t(__CLASS__ . '.COLUMN_METHODS_REGISTERED', 'Method names'),
+            'defaultMethodName' => _t(__CLASS__ . '.COLUMN_METHOD_DEFAULT', 'Default method'),
+            'skippedRegistration' => _t(__CLASS__ . '.COLUMN_SKIPPED_REGISTRATION', 'Skipped registration'),
+        ];
+        $this->extend('updateColumns', $columns);
+        return $columns;
+    }
+
+    /**
+     * Provides the fields used to gather input to filter the report
+     *
+     * @return FieldList
+     */
+    public function parameterFields(): FieldList
+    {
+        $methods = $this->getMethodClassToTitleMapping();
+        unset($methods[$this->getBackupMethodClass()]);
+        $parameterFields = FieldList::create(
+            TextField::create(
+                'Member',
+                singleton(Member::class)->i18n_singular_name()
+            )->setDescription(_t(
+                __CLASS__ . '.FILTER_MEMBER_DESCRIPTION',
+                'Firstname, Surname, Email partial match search'
+            )),
+            NumericField::create(
+                'Count',
+                _t(__CLASS__ . '.COLUMN_METHOD_COUNT', 'Number of registered methods')
+            )->setHTML5(true),
+            DropdownField::create(
+                'Methods',
+                _t(__CLASS__ . '.COLUMN_METHODS_REGISTERED', 'Registered methods'),
+                $methods,
+                ''
+            )->setHasEmptyDefault(true),
+            CheckboxField::create(
+                'Skipped',
+                _t(__CLASS__ . '.COLUMN_SKIPPED_REGISTRATION', 'Skipped registration')
+            )
+        );
+        $this->extend('updateParameterFields', $parameterFields);
+        return $parameterFields;
+    }
+
+    /**
+     * Create an array mapping authentication method Class Names to Readable Names
+     *
+     * @return array
+     */
+    protected function getMethodClassToTitleMapping(): array
+    {
+        $methods = singleton(MethodRegistry::class)->getMethods();
+        $methodsClasses = array_map(
+            function (MethodInterface $method): string {
+                return get_class($method);
+            },
+            $methods
+        );
+        $methodNames = array_map(
+            function (MethodInterface $method): string {
+                return $method->getName();
+            },
+            $methods
+        );
+        return array_combine($methodsClasses, $methodNames);
+    }
+
+    /**
+     * Applies parameters to source records for filtering purposes.
+     *
+     * @param Filterable $params
+     * @param array $params
+     * @return SS_List
+     */
+    protected function applyParams(Filterable $sourceList, array $params): SS_List
+    {
+        $map = [
+            'Member' => ['FirstName:PartialMatch', 'Surname:PartialMatch', 'Email:PartialMatch'],
+            'Count' => 'RegisteredMFAMethods.Count()',
+            'Methods' => 'RegisteredMFAMethods.MethodClassName',
+            'Skipped' => 'HasSkippedMFARegistration',
+        ];
+        $this->extend('updateParameterMap', $map);
+        foreach ($map as $submissionName => $searchKey) {
+            if (isset($params[$submissionName])) {
+                if (is_array($searchKey)) {
+                    $sourceList = $sourceList->filterAny(array_fill_keys($searchKey, $params[$submissionName]));
+                } else {
+                    $sourceList = $sourceList->filter($searchKey, $params[$submissionName]);
+                }
+            }
+        }
+        return $sourceList;
+    }
+
+    /**
+     * Returns the PHP class name of the configured backup method in the MFA module
+     *
+     * @return string
+     */
+    private function getBackupMethodClass(): string
+    {
+        return get_class(singleton(MethodRegistry::class)->getBackupMethod());
+    }
+}

--- a/tests/php/Report/EnabledMembersTest.php
+++ b/tests/php/Report/EnabledMembersTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\Report;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\DropdownField;
+use SilverStripe\MFA\BackupCode\Method as BackupMethod;
+use SilverStripe\MFA\Report\EnabledMembers;
+use SilverStripe\MFA\Service\MethodRegistry;
+use SilverStripe\MFA\Tests\Stub\BasicMath\Method as BasicMathMethod;
+use SilverStripe\MFA\Tests\Stub\Null\Method as NullMethod;
+
+class EnabledMembersTest extends SapphireTest
+{
+    protected static $fixture_file = 'EnabledMembersTest.yml';
+
+    protected function setUp()
+    {
+        parent::setUp();
+        Config::modify()
+            ->set(MethodRegistry::class, 'default_backup_method', BackupMethod::class)
+            ->set(MethodRegistry::class, 'methods', [BasicMathMethod::class, NullMethod::class, BackupMethod::class]);
+    }
+
+    public function testRegisteredMethodFilterFieldDoesNotContainBackupMethod()
+    {
+        $report = new EnabledMembers();
+        $fields = $report->parameterFields();
+        /** @var DropdownField $registeredMethodFilterField */
+        $registeredMethodFilterField = $fields->dataFieldByName('Methods');
+        $source = $registeredMethodFilterField->getSource();
+        $this->assertArrayNotHasKey(BackupMethod::class, $source);
+    }
+
+    /**
+     * @dataProvider sourceRecordsParamsProvider
+     * @param array $params
+     * @param int $expectedRows
+     * @param string $explanation
+     */
+    public function testSourceRecords($params, $expectedRows, $explanation = null)
+    {
+        $report = new EnabledMembers();
+        $records = $report->sourceRecords($params);
+        $this->assertEquals($expectedRows, $records->count(), $explanation);
+    }
+
+    public function sourceRecordsParamsProvider()
+    {
+        return [
+            [[], 5, 'Sanity test'],
+            [['Skipped' => '1'], 2, 'Skipped setup filter works'],
+            [['Skipped' => '1', 'Count' => '0'], 1, 'Show members that have skipped and do not have a method set up'],
+            [['Count' => '2'], 1, 'Filtering by number of methods set up works'],
+            [['Count' => '2', 'Methods' => BasicMathMethod::class], 1, 'Count and Methods fitlers work together'],
+            [
+                ['Member' => 'i'],
+                4,
+                'Searching for a member works over FirstName or Surname and is a disjunctive partial match'
+            ],
+            [['Member' => '.com'], 4, 'Member search includes Email'],
+            [['Methods' => BasicMathMethod::class], 2, 'Searching for a particular method works'],
+            [
+                ['Methods' => BasicMathMethod::class, 'Member' => 'EDITOR', 'Count' => '1', 'Skipped' => '1'],
+                1,
+                'Control test that all filters are conjunctive'
+            ],
+            [['Methods' => BasicMathMethod::class, 'Member' => 'EDITOR', 'Count' => '1', 'Skipped' => '0'], 0],
+            [['Methods' => BasicMathMethod::class, 'Member' => 'EDITOR', 'Count' => '2', 'Skipped' => '1'], 0],
+            [['Methods' => BasicMathMethod::class, 'Member' => 'MFA', 'Count' => '1', 'Skipped' => '1'], 0],
+            [['Methods' => NullMethod::class, 'Member' => 'EDITOR', 'Count' => '1', 'Skipped' => '1'], 0],
+            [['Methods' => NullMethod::class, 'Member' => 'MFA', 'Count' => '2', 'Skipped' => '0'], 1],
+            [
+                ['Methods' => '', 'Member' => '', 'Count' => '', 'Skipped' => ''],
+                5,
+                'An empty filter input set does not destroy the result set'
+            ],
+        ];
+    }
+}

--- a/tests/php/Report/EnabledMembersTest.yml
+++ b/tests/php/Report/EnabledMembersTest.yml
@@ -1,0 +1,49 @@
+SilverStripe\MFA\Model\RegisteredMethod:
+  mfa0:
+    MethodClassName: SilverStripe\MFA\BackupCode\Method
+  mfa1:
+    MethodClassName: SilverStripe\MFA\Tests\Stub\BasicMath\Method
+  mfa2:
+    MethodClassName: SilverStripe\MFA\Tests\Stub\Null\Method
+  mfa3:
+    MethodClassName: SilverStripe\MFA\BackupCode\Method
+  mfa4:
+    MethodClassName: SilverStripe\MFA\Tests\Stub\BasicMath\Method
+  mfa5:
+    MethodClassName: SilverStripe\MFA\BackupCode\Method
+  mfa6:
+    MethodClassName: SilverStripe\MFA\Tests\Stub\Null\Method
+
+SilverStripe\Security\Member:
+  # SapphireTest will inject "ADMIN User admin@example.org" at setUp - v4.4.1 line 307 (31 July 2019)
+  # So although there are only 4 Members defined here, there will be 5 at test runtime.
+  admin:
+    FirstName: Angela
+    Surname: "D'Min"
+    Email: admin@example.com
+    RegisteredMFAMethods:
+      - =>SilverStripe\MFA\Model\RegisteredMethod.mfa5
+      - =>SilverStripe\MFA\Model\RegisteredMethod.mfa6
+  priviliged:
+    FirstName: Eleanor
+    Surname: "Ditor"
+    Email: editor@example.com
+    RegisteredMFAMethods:
+      - =>SilverStripe\MFA\Model\RegisteredMethod.mfa3
+      - =>SilverStripe\MFA\Model\RegisteredMethod.mfa4
+    DefaultRegisteredMethodID: =>SilverStripe\MFA\Model\RegisteredMethod.mfa3
+    HasSkippedMFARegistration: true
+  mfa:
+    FirstName: Michelle
+    Surname: Fa
+    Email: mfa@example.com
+    RegisteredMFAMethods:
+      - =>SilverStripe\MFA\Model\RegisteredMethod.mfa0
+      - =>SilverStripe\MFA\Model\RegisteredMethod.mfa1
+      - =>SilverStripe\MFA\Model\RegisteredMethod.mfa2
+    DefaultRegisteredMethodID: =>SilverStripe\MFA\Model\RegisteredMethod.mfa1
+  user:
+    FirstName: Ursula
+    Surname: Ser
+    Email: user@example.com
+    HasSkippedMFARegistration: true

--- a/tests/php/Stub/Null/Method.php
+++ b/tests/php/Stub/Null/Method.php
@@ -18,7 +18,7 @@ class Method implements MethodInterface, TestOnly
      */
     public function getName(): string
     {
-        // TODO: Implement getName() method.
+        return 'Null';
     }
 
     /**


### PR DESCRIPTION
In order to aid administrators with the up-take of MFA on their site, a
report can be used to show which users are yet to set up a method, etc.

Resolves #114