### PR TITLE
Add missing bootstrap dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@silverstripe/react-injector": "^0.2.0",
     "@silverstripe/reactstrap-confirm": "^0.0.4",
+    "bootstrap": "^4.3.1",
     "classnames": "^2.2.6",
     "core-js": "^3.1.4",
     "es6-promise": "^4.2.8",


### PR DESCRIPTION
`bootstrap` was already a dependency but it wasn't explicitly stated. In the end `reactstrap-confirm` was already providing it for us.