### PR TITLE
NEW Add links to userhelp documentation

### DIFF
--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -60,7 +60,7 @@ class LoginHandler extends BaseLoginHandler
      * @config
      * @var string
      */
-    private static $user_help_link = '';
+    private static $user_help_link = 'https://userhelp.silverstripe.org/en/4/optional_features/multi-factor_authentication/'; // phpcs-disable-line
 
     /**
      * @var string[]

--- a/src/BackupCode/RegisterHandler.php
+++ b/src/BackupCode/RegisterHandler.php
@@ -23,12 +23,11 @@ class RegisterHandler implements RegisterHandlerInterface
 
     /**
      * Provide a user help link that will be available when registering backup codes
-     * TODO Will this have a user help link as a default?
      *
      * @config
      * @var string
      */
-    private static $user_help_link;
+    private static $user_help_link = 'https://userhelp.silverstripe.org/en/4/optional_features/multi-factor_authentication/user_manual/regaining_access/'; // phpcs-disable-line
 
     /**
      * Stores any data required to handle a registration process with a method, and returns relevant state to be applied


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-mfa/issues/239. Requires https://github.com/silverstripe/silverstripe-userhelp-   content/pull/137.