### PR TITLE
FIX Prevent incompatible versions of Subsites from installing alongside MFA

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
         "phpunit/phpunit": "^5.7",
         "squizlabs/php_codesniffer": "^3.0"
     },
+    "conflict": {
+        "silverstripe/subsites": "<2.3.1"
+    },
     "suggest": {
         "silverstripe/totp-authenticator": "Adds a method to authenticate with you phone using a time-based one-time password.",
         "silverstripe/webauthn-authenticator": "Adds a method to authenticate with security keys or built-in platform authenticators."


### PR DESCRIPTION
In `silverstripe/subsites 2.3.1`, we introduced a fix that was causing the MFA module to stop authenticating users when used alongside Subsites. That fix is mandatory for a stable install - so this PR marks earlier versions as conflicting.