### PR TITLE
DOCS userhelp note for subsites

### DIFF
--- a/docs/en/userguide/01_User_manual/03_Using_security_keys.md
+++ b/docs/en/userguide/01_User_manual/03_Using_security_keys.md
@@ -23,6 +23,10 @@ You must also log in via **HTTPS**. If there is no padlock in the address bar
 of your browser, try changing `http://` to `https://` at the beginning of the
 address.
 
+<div class="notice" markdown='1'>
+Security keys are not recommended for use with Subsites. If you intend to log in to a Subsite over a different website domain to your main site, your security key will not be compatible. This is an intentional security requirement of the WebnAuthn standard.
+</div>
+
 ## Setting up with a security key
 
 Enter the MFA setup process. Pick **Security key** from the Select Method

--- a/docs/en/userguide/01_User_manual/03_Using_security_keys.md
+++ b/docs/en/userguide/01_User_manual/03_Using_security_keys.md
@@ -24,7 +24,7 @@ of your browser, try changing `http://` to `https://` at the beginning of the
 address.
 
 <div class="notice" markdown='1'>
-Security keys are not recommended for use with Subsites. If you intend to log in to a Subsite over a different website domain to your main site, your security key will not be compatible. This is an intentional security requirement of the WebnAuthn standard.
+Security keys are not recommended for use with Subsites. If you intend to log in to a Subsite over a different website domain to your main site, your security key will not be compatible. This is an intentional security requirement of the WebAuthn standard.
 </div>
 
 ## Setting up with a security key


### PR DESCRIPTION
Security keys are not recommended for use with Subsites. This makes a note in the userhelp docs.

Resolves https://github.com/silverstripe/silverstripe-webauthn-authenticator/issues/58

[ci skip]