### PR TITLE
FIX Allow compatibility with patched releases of Subsites 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "squizlabs/php_codesniffer": "^3.0"
     },
     "conflict": {
-        "silverstripe/subsites": "<2.3.1"
+        "silverstripe/subsites": "<2.2.2 || 2.3.0"
     },
     "suggest": {
         "silverstripe/totp-authenticator": "Adds a method to authenticate with you phone using a time-based one-time password.",

--- a/src/Authenticator/ChangePasswordHandler.php
+++ b/src/Authenticator/ChangePasswordHandler.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Authenticator;
 
@@ -205,7 +207,8 @@ class ChangePasswordHandler extends BaseChangePasswordHandler
         /** @var Member&MemberExtension $member */
         $member = Member::member_from_autologinhash($hash);
 
-        if ($hash
+        if (
+            $hash
             && $member
             && $member->RegisteredMFAMethods()->exists()
             && !$session->get(self::MFA_VERIFIED_ON_CHANGE_PASSWORD)

--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Authenticator;
 
@@ -188,7 +190,8 @@ class LoginHandler extends BaseLoginHandler
         $sessionMember = $store ? $store->getMember() : null;
         $loggedInMember = Security::getCurrentUser();
 
-        if (($loggedInMember === null && $sessionMember === null)
+        if (
+            ($loggedInMember === null && $sessionMember === null)
             || !$this->getSudoModeService()->check($request->getSession())
         ) {
             return $this->jsonResponse(
@@ -251,7 +254,8 @@ class LoginHandler extends BaseLoginHandler
         $sessionMember = $store ? $store->getMember() : null;
         $loggedInMember = Security::getCurrentUser();
 
-        if (($loggedInMember === null && $sessionMember === null)
+        if (
+            ($loggedInMember === null && $sessionMember === null)
             || !$this->getSudoModeService()->check($request->getSession())
         ) {
             return $this->jsonResponse(
@@ -284,7 +288,8 @@ class LoginHandler extends BaseLoginHandler
         // required to log in though. The "mustLogin" flag is set at the beginning of the MFA process if they have at
         // least one method registered. They should always do that first. In that case we should assert
         // "isLoginComplete"
-        if ((!$mustLogin || $this->isVerificationComplete($store))
+        if (
+            (!$mustLogin || $this->isVerificationComplete($store))
             && $enforcementManager->hasCompletedRegistration($sessionMember)
         ) {
             $this->doPerformLogin($request, $sessionMember);
@@ -447,7 +452,8 @@ class LoginHandler extends BaseLoginHandler
         // This is potentially redundant logic as the member should only be logged in if they've fully registered.
         // They're allowed to login if they can skip - so only do assertions if they're not allowed to skip
         // We'll also check that they've registered the required MFA details
-        if (!$enforcementManager->canSkipMFA($member)
+        if (
+            !$enforcementManager->canSkipMFA($member)
             && !$enforcementManager->hasCompletedRegistration($member)
         ) {
             // Log them out again

--- a/src/Authenticator/MemberAuthenticator.php
+++ b/src/Authenticator/MemberAuthenticator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace SilverStripe\MFA\Authenticator;
 
 use SilverStripe\Security\MemberAuthenticator\MemberAuthenticator as BaseMemberAuthenticator;

--- a/src/BackupCode/Method.php
+++ b/src/BackupCode/Method.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\BackupCode;
 

--- a/src/BackupCode/RegisterHandler.php
+++ b/src/BackupCode/RegisterHandler.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\BackupCode;
 

--- a/src/BackupCode/VerifyHandler.php
+++ b/src/BackupCode/VerifyHandler.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\BackupCode;
 

--- a/src/Controller/AdminRegistrationController.php
+++ b/src/Controller/AdminRegistrationController.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Controller;
 
@@ -195,7 +197,8 @@ class AdminRegistrationController extends LeftAndMain
     public function setDefaultRegisteredMethod(HTTPRequest $request): HTTPResponse
     {
         // Ensure CSRF and sudo-mode protection
-        if (!SecurityToken::inst()->checkRequest($request)
+        if (
+            !SecurityToken::inst()->checkRequest($request)
             || !$this->getSudoModeService()->check($request->getSession())
         ) {
             return $this->jsonResponse(

--- a/src/Exception/InvalidMethodException.php
+++ b/src/Exception/InvalidMethodException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace SilverStripe\MFA\Exception;
 
 use LogicException;

--- a/src/Extension/AccountReset/MFAResetExtension.php
+++ b/src/Extension/AccountReset/MFAResetExtension.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Extension\AccountReset;
 

--- a/src/Extension/AccountReset/MemberExtension.php
+++ b/src/Extension/AccountReset/MemberExtension.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Extension\AccountReset;
 
@@ -45,9 +47,11 @@ class MemberExtension extends DataExtension
         do {
             $token = $generator->randomToken();
             $hash = $this->owner->encryptWithUserSettings($token);
-        } while (DataObject::get_one(Member::class, [
+        } while (
+            DataObject::get_one(Member::class, [
             '"Member"."AccountResetHash"' => $hash,
-        ]));
+            ])
+        );
 
         $this->owner->AccountResetHash = $hash;
         $this->owner->AccountResetExpired = DBDatetime::create()->setValue(

--- a/src/Extension/AccountReset/SecurityAdminExtension.php
+++ b/src/Extension/AccountReset/SecurityAdminExtension.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Extension\AccountReset;
 

--- a/src/Extension/AccountReset/SecurityExtension.php
+++ b/src/Extension/AccountReset/SecurityExtension.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Extension\AccountReset;
 

--- a/src/Extension/MemberExtension.php
+++ b/src/Extension/MemberExtension.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Extension;
 

--- a/src/JSONResponse.php
+++ b/src/JSONResponse.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA;
 

--- a/src/Method/Handler/RegisterHandlerInterface.php
+++ b/src/Method/Handler/RegisterHandlerInterface.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Method\Handler;
 

--- a/src/Method/Handler/VerifyHandlerInterface.php
+++ b/src/Method/Handler/VerifyHandlerInterface.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Method\Handler;
 

--- a/src/Method/MethodInterface.php
+++ b/src/Method/MethodInterface.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Method;
 

--- a/src/Model/RegisteredMethod.php
+++ b/src/Model/RegisteredMethod.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Model;
 

--- a/src/Report/EnabledMembers.php
+++ b/src/Report/EnabledMembers.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Report;
 

--- a/src/Service/BackupCodeGenerator.php
+++ b/src/Service/BackupCodeGenerator.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Service;
 

--- a/src/Service/BackupCodeGeneratorInterface.php
+++ b/src/Service/BackupCodeGeneratorInterface.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Service;
 

--- a/src/Service/EncryptionAdapterInterface.php
+++ b/src/Service/EncryptionAdapterInterface.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Service;
 

--- a/src/Service/EnforcementManager.php
+++ b/src/Service/EnforcementManager.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Service;
 
@@ -229,7 +231,8 @@ class EnforcementManager
         // Look through all LeftAndMain subclasses to find if one permits the member to view
         $menu = $leftAndMain->MainMenu();
         foreach ($menu as $candidate) {
-            if ($candidate->Link
+            if (
+                $candidate->Link
                 && $candidate->Link !== $leftAndMain->Link()
                 && $candidate->MenuItem->controller
                 && singleton($candidate->MenuItem->controller)->canView($member)

--- a/src/Service/MethodRegistry.php
+++ b/src/Service/MethodRegistry.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Service;
 

--- a/src/Service/Notification.php
+++ b/src/Service/Notification.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Service;
 

--- a/src/Service/RegisteredMethodManager.php
+++ b/src/Service/RegisteredMethodManager.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Service;
 

--- a/src/State/AvailableMethodDetails.php
+++ b/src/State/AvailableMethodDetails.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\State;
 

--- a/src/State/BackupCode.php
+++ b/src/State/BackupCode.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\State;
 

--- a/src/State/RegisteredMethodDetails.php
+++ b/src/State/RegisteredMethodDetails.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\State;
 

--- a/src/State/Result.php
+++ b/src/State/Result.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\State;
 

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Store;
 

--- a/src/Store/StoreInterface.php
+++ b/src/Store/StoreInterface.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Store;
 

--- a/tests/Behat/Context/LoginContext.php
+++ b/tests/Behat/Context/LoginContext.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Tests\Behat\Context;
 

--- a/tests/php/Service/BackupCodeGeneratorTest.php
+++ b/tests/php/Service/BackupCodeGeneratorTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Service;
 

--- a/tests/php/Stub/BasicMath/Method.php
+++ b/tests/php/Stub/BasicMath/Method.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace SilverStripe\MFA\Tests\Stub\BasicMath;
 
 use SilverStripe\Control\Director;

--- a/tests/php/Stub/BasicMath/MethodRegisterHandler.php
+++ b/tests/php/Stub/BasicMath/MethodRegisterHandler.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Tests\Stub\BasicMath;
 

--- a/tests/php/Stub/BasicMath/MethodVerifyHandler.php
+++ b/tests/php/Stub/BasicMath/MethodVerifyHandler.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\MFA\Tests\Stub\BasicMath;
 


### PR DESCRIPTION
The 2.2 branch of CWP Kitchen Sink was failing due to containing MFA, but not containing a recent enough version of Subsites. The fix required for MFA to be compatible with Subsites was already present in the 2.2 branch, so I've tagged `2.2.2`. This PR loosens the conflict to allow it to be installed alongside MFA.

This PR also contains a myriad of linting fixes, due to changes in the code formatting standard we pull in.