### PR TITLE
DOCS remove empty docs file

### DIFF
--- a/docs/en/controllers-and-handlers.md
+++ b/docs/en/controllers-and-handlers.md
@@ -1,2 +1,0 @@
-# Controllers and handlers
-

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,6 @@ functionality:
 - Creating new MFA methods
   - [Frontend](docs/en/creating-mfa-method-frontend.md)
   - [Backend](docs/en/creating-mfa-method-backend.md)
-- [Back-end controllers and traits](docs/en/controllers-and-handlers.md)
 - [Local development](docs/en/local-development.md)
 - [Encryption providers](docs/en/encryption.md)
 - [Data store interfaces](docs/en/datastores.md)


### PR DESCRIPTION
I can't see an open issue covering a task to add contents to this file.

Given it is empty, I'm suggesting we remove it to tidy up what's currently there.

[ci-skip]