### PR TITLE
BUG Expose the client/lang directory so we can load JS side translation properly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
             "dev-master": "4.x-dev"
         },
         "expose": [
-            "client/dist"
+            "client/dist",
+            "client/lang"
         ]
     },
     "autoload": {


### PR DESCRIPTION
MFA tries to load language JS files that haven't been exposed.

This PR expose the `client/lang` folder as was intendended.