### PR TITLE
FIX Members minimal CMS access were previously stuck in a login loop, now redirects to MFA

### DIFF
--- a/src/Service/EnforcementManager.php
+++ b/src/Service/EnforcementManager.php
@@ -98,8 +98,13 @@ class EnforcementManager
             return false;
         }
 
-        if ($this->config()->get('requires_admin_access') && !$this->hasAdminAccess($member)) {
-            return false;
+        if ($this->config()->get('requires_admin_access')) {
+            $hasAdminAccess = Member::actAs($member, function () use ($member) {
+                return $this->hasAdminAccess($member);
+            });
+            if (!$hasAdminAccess) {
+                return false;
+            }
         }
 
         $methodRegistry = MethodRegistry::singleton();
@@ -229,7 +234,7 @@ class EnforcementManager
         }
 
         // Look through all LeftAndMain subclasses to find if one permits the member to view
-        $menu = $leftAndMain->MainMenu();
+        $menu = $leftAndMain->MainMenu(false);
         foreach ($menu as $candidate) {
             if (
                 $candidate->Link


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-mfa/issues/369 for SS 4

This allows https://github.com/silverstripe/silverstripe-admin/blob/1/code/LeftAndMain.php#L1007-L1010 to not return an empty list during MFA enabled login flows.