### PR TITLE
FIX Check whether user is eligible for MFA in canSkipMFA method

### DIFF
--- a/src/Service/EnforcementManager.php
+++ b/src/Service/EnforcementManager.php
@@ -50,44 +50,44 @@ class EnforcementManager
     private static $enabled = true;
 
     /**
-     * Whether the current member can skip the multi-factor authentication registration process.
+     * Whether the provided member can skip the MFA registration process.
      *
      * This is determined by a combination of:
-     *  - Whether MFA is required or optional
-     *  - If MFA is required, whether there is a grace period
-     *  - If MFA is required and there is a grace period, whether we're currently within that timeframe
+     *
+     *  - Whether the user has admin access (MFA is disabled by default for users that don't)
+     *  - Whether MFA is required - @see EnforcementManager::isMFARequired()
+     *  - Whether the user has registered MFA methods already
      *
      * @param Member&MemberExtension $member
      * @return bool
      */
     public function canSkipMFA(Member $member): bool
     {
+        if ($this->config()->get('requires_admin_access') && !$this->hasAdminAccess($member)) {
+            return true;
+        }
+
         if ($this->isMFARequired()) {
             return false;
         }
 
-        // If they've already registered MFA methods we will not allow them to skip the authentication process
-        $registeredMethods = $member->RegisteredMFAMethods();
-        if ($registeredMethods->exists()) {
+        if ($member->RegisteredMFAMethods()->exists()) {
             return false;
         }
 
-        // MFA is optional, or is required but might be within a grace period (see isMFARequired)
         return true;
     }
 
     /**
-     * Whether the authentication process should redirect the user to multi-factor authentication registration or
-     * login.
+     * Whether the authentication process should redirect the provided user to MFA registration or login.
      *
      * This is determined by a combination of:
-     *  - Whether MFA is enabled
-     *  - Whether MFA is required or optional
-     *  - Whether the user has registered MFA methods already
-     *  - If the user doesn't have any registered MFA methods already, and MFA is optional, whether the user has opted
-     *    to skip the registration process
      *
-     * Note that in determining this, we ignore whether or not MFA is enabled for the site in general.
+     *  - Whether MFA is enabled and there are methods available for use
+     *  - Whether the user has admin access (MFA is disabled by default for users that don't)
+     *  - Whether the user has existing MFA methods registered
+     *  - Whether the grace period is in effect (we always redirect eligible users in this case)
+     *  - Whether the user has previously opted to skip the registration process
      *
      * @param Member&MemberExtension $member
      * @return bool
@@ -98,19 +98,14 @@ class EnforcementManager
             return false;
         }
 
-        if ($this->config()->get('requires_admin_access')) {
-            $hasAdminAccess = Member::actAs($member, function () use ($member) {
-                return $this->hasAdminAccess($member);
-            });
-            if (!$hasAdminAccess) {
-                return false;
-            }
-        }
-
         $methodRegistry = MethodRegistry::singleton();
         $methods = $methodRegistry->getMethods();
         // If there are no methods available excluding backup codes, do not redirect
         if (!count($methods) || (count($methods) === 1 && $methodRegistry->getBackupMethod() !== null)) {
+            return false;
+        }
+
+        if ($this->config()->get('requires_admin_access') && !$this->hasAdminAccess($member)) {
             return false;
         }
 
@@ -134,9 +129,8 @@ class EnforcementManager
     }
 
     /**
-     * Check if the provided member has registered the required MFA methods. This includes a "back-up" method set in
-     * configuration plus at least one other method.
-     * Note that this method returns true if there is no backup method registered (and they have one other method
+     * Check if the provided member has registered the required MFA methods. This includes the default backup method
+     * if configured, and at least one other method.
      *
      * @param Member&MemberExtension $member
      * @return bool
@@ -156,8 +150,8 @@ class EnforcementManager
     }
 
     /**
-     * Whether multi-factor authentication is required for site members. This also takes into account whether a
-     * grace period is set and whether we're currently inside the window for it.
+     * Whether MFA is required for eligible users. This takes into account whether a grace period is set and whether
+     * we're currently inside the window for it.
      *
      * Note that in determining this, we ignore whether or not MFA is enabled for the site in general.
      *
@@ -218,35 +212,36 @@ class EnforcementManager
     }
 
     /**
-     * Decides whether the current user has access to any LeftAndMain controller, which indicates some level
+     * Decides whether the provided user has access to any LeftAndMain controller, which indicates some level
      * of access to the CMS.
      *
-     * See LeftAndMain::init().
-     *
+     * @see LeftAndMain::init()
      * @param Member $member
      * @return bool
      */
     protected function hasAdminAccess(Member $member): bool
     {
-        $leftAndMain = LeftAndMain::singleton();
-        if ($leftAndMain->canView($member)) {
-            return true;
-        }
-
-        // Look through all LeftAndMain subclasses to find if one permits the member to view
-        $menu = $leftAndMain->MainMenu(false);
-        foreach ($menu as $candidate) {
-            if (
-                $candidate->Link
-                && $candidate->Link !== $leftAndMain->Link()
-                && $candidate->MenuItem->controller
-                && singleton($candidate->MenuItem->controller)->canView($member)
-            ) {
+        return Member::actAs($member, function () use ($member) {
+            $leftAndMain = LeftAndMain::singleton();
+            if ($leftAndMain->canView($member)) {
                 return true;
             }
-        }
 
-        return false;
+            // Look through all LeftAndMain subclasses to find if one permits the member to view
+            $menu = $leftAndMain->MainMenu(false);
+            foreach ($menu as $candidate) {
+                if (
+                    $candidate->Link
+                    && $candidate->Link !== $leftAndMain->Link()
+                    && $candidate->MenuItem->controller
+                    && singleton($candidate->MenuItem->controller)->canView($member)
+                ) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
     }
 
     /**

--- a/src/Service/EnforcementManager.php
+++ b/src/Service/EnforcementManager.php
@@ -86,7 +86,8 @@ class EnforcementManager
      *  - Whether MFA is enabled and there are methods available for use
      *  - Whether the user has admin access (MFA is disabled by default for users that don't)
      *  - Whether the user has existing MFA methods registered
-     *  - Whether the grace period is in effect (we always redirect eligible users in this case)
+     *  - Whether a grace period is in effect (we always redirect eligible users in this case)
+     *  - Whether MFA is mandatory (without a grace period or after it has expired)
      *  - Whether the user has previously opted to skip the registration process
      *
      * @param Member&MemberExtension $member
@@ -113,11 +114,11 @@ class EnforcementManager
             return true;
         }
 
-        if ($this->isMFARequired()) {
+        if ($this->isGracePeriodInEffect()) {
             return true;
         }
 
-        if ($this->isGracePeriodInEffect()) {
+        if ($this->isMFARequired()) {
             return true;
         }
 

--- a/tests/php/Service/EnforcementManagerTest.php
+++ b/tests/php/Service/EnforcementManagerTest.php
@@ -195,9 +195,7 @@ class EnforcementManagerTest extends SapphireTest
         $this->setSiteConfig(['MFARequired' => false]);
 
         /** @var Member&MemberExtension $member */
-        $member = $this->objFromFixture(Member::class, 'sammy_smith');
-        $member->HasSkippedMFARegistration = true;
-        $member->write();
+        $member = $this->objFromFixture(Member::class, 'sully_smith');
         $this->logInAs($member);
 
         $this->assertFalse(EnforcementManager::create()->shouldRedirectToMFA($member));
@@ -228,6 +226,16 @@ class EnforcementManagerTest extends SapphireTest
     {
         $this->setSiteConfig(['MFARequired' => true]);
         $this->assertFalse(EnforcementManager::create()->isGracePeriodInEffect());
+    }
+
+    public function testUserHasCompletedRegistrationWhenBackupMethodIsDisabled()
+    {
+        MethodRegistry::config()->set('default_backup_method', null);
+
+        /** @var Member $member */
+        $member = $this->objFromFixture(Member::class, 'sally_smith');
+
+        $this->assertTrue(EnforcementManager::create()->hasCompletedRegistration($member));
     }
 
     /**

--- a/tests/php/Service/EnforcementManagerTest.php
+++ b/tests/php/Service/EnforcementManagerTest.php
@@ -40,16 +40,12 @@ class EnforcementManagerTest extends SapphireTest
 
     public function testUserWithoutCMSAccessCannotSkipWhenCMSAccessIsNotRequired()
     {
-        Config::nest();
-
         $this->setSiteConfig(['MFARequired' => true]);
         EnforcementManager::config()->set('requires_admin_access', false);
 
         /** @var Member $member */
         $member = $this->objFromFixture(Member::class, 'sammy_smith');
         $this->assertFalse(EnforcementManager::create()->canSkipMFA($member));
-
-        Config::unnest();
     }
 
     public function testCannotSkipWhenMFAIsRequiredWithNoGracePeriod()
@@ -111,14 +107,12 @@ class EnforcementManagerTest extends SapphireTest
 
     public function testShouldRedirectToMFAWhenUserDoesNotHaveCMSAccessButTheCheckIsDisabledWithConfig()
     {
-        Config::nest();
         EnforcementManager::config()->set('requires_admin_access', false);
 
         /** @var Member $member */
         $member = $this->objFromFixture(Member::class, 'sammy_smith');
         $this->logInAs($member);
         $this->assertTrue(EnforcementManager::create()->shouldRedirectToMFA($member));
-        Config::unnest();
     }
 
     public function testShouldRedirectToMFAWhenUserHasAccessToReportsOnly()

--- a/tests/php/Service/EnforcementManagerTest.php
+++ b/tests/php/Service/EnforcementManagerTest.php
@@ -149,7 +149,7 @@ class EnforcementManagerTest extends SapphireTest
     {
         $this->setSiteConfig(['MFARequired' => true]);
         /** @var Member $member */
-        $member = $this->objFromFixture(Member::class, 'sally_smith');
+        $member = $this->objFromFixture(Member::class, 'sully_smith');
         $this->logInAs($member);
 
         $this->assertTrue(EnforcementManager::create()->shouldRedirectToMFA($member));
@@ -157,28 +157,24 @@ class EnforcementManagerTest extends SapphireTest
 
     public function testShouldRedirectToMFAWhenMFAIsRequiredWithGracePeriodExpiringInFuture()
     {
-        $this->setSiteConfig(['MFARequired' => false, 'MFAGracePeriodExpires' => '2019-01-30']);
+        $this->setSiteConfig(['MFARequired' => true, 'MFAGracePeriodExpires' => '2019-01-30']);
 
         /** @var Member&MemberExtension $member */
-        $member = $this->objFromFixture(Member::class, 'sammy_smith');
-        $member->HasSkippedMFARegistration = true;
-        $member->write();
+        $member = $this->objFromFixture(Member::class, 'sully_smith');
         $this->logInAs($member);
 
-        $this->assertFalse(EnforcementManager::create()->shouldRedirectToMFA($member));
+        $this->assertTrue(EnforcementManager::create()->shouldRedirectToMFA($member));
     }
 
     public function testShouldRedirectToMFAWhenMFAIsRequiredWithGracePeriodExpiringInPast()
     {
-        $this->setSiteConfig(['MFARequired' => false, 'MFAGracePeriodExpires' => '2018-12-25']);
+        $this->setSiteConfig(['MFARequired' => true, 'MFAGracePeriodExpires' => '2018-12-25']);
 
         /** @var Member&MemberExtension $member */
-        $member = $this->objFromFixture(Member::class, 'sammy_smith');
-        $member->HasSkippedMFARegistration = true;
-        $member->write();
+        $member = $this->objFromFixture(Member::class, 'sully_smith');
         $this->logInAs($member);
 
-        $this->assertFalse(EnforcementManager::create()->shouldRedirectToMFA($member));
+        $this->assertTrue(EnforcementManager::create()->shouldRedirectToMFA($member));
     }
 
     public function testShouldRedirectToMFAWhenMFAIsOptionalAndHasNotBeenSkipped()
@@ -226,6 +222,12 @@ class EnforcementManagerTest extends SapphireTest
         $this->logInAs($member);
 
         $this->assertFalse(EnforcementManager::create()->shouldRedirectToMFA($member));
+    }
+
+    public function testGracePeriodIsNotInEffectWhenMFAIsRequiredButNoGracePeriodIsSet()
+    {
+        $this->setSiteConfig(['MFARequired' => true]);
+        $this->assertFalse(EnforcementManager::create()->isGracePeriodInEffect());
     }
 
     /**

--- a/tests/php/Service/EnforcementManagerTest.yml
+++ b/tests/php/Service/EnforcementManagerTest.yml
@@ -31,6 +31,12 @@ SilverStripe\Security\Member:
     FirstName: Sammy
     Surname: Smith
     Email: sammy.smith@example.com
+  sully_smith:
+    FirstName: Sully
+    Surname: Smith
+    Email: sully.smith@example.com
+    Groups: =>SilverStripe\Security\Group.reportsgroup
+    HasSkippedMFARegistration: true
   reports_user:
     FirstName: Reports
     Surname: User


### PR DESCRIPTION
Users with no CMS access are not eligible to use MFA by default. This was respected in the shouldRedirectToMFA method, but not in canSkipMFA, which resulted in these users being booted back to the login screen whenever they attempted to log in.

This commit also tidies some of the docblocks in EnforcementManager, and adjusts the hasAdminAccess method to always act as the provided Member.

Will resolve #376 for the 4.0 branch; requires backporting to 3.0 alongside #369.