### PR TITLE
FIX Ensure canSkipMFA respects whether MFA is enabled

### DIFF
--- a/tests/php/Service/EnforcementManagerTest.php
+++ b/tests/php/Service/EnforcementManagerTest.php
@@ -27,6 +27,27 @@ class EnforcementManagerTest extends SapphireTest
         ]);
 
         EnforcementManager::config()->set('requires_admin_access', true);
+        EnforcementManager::config()->set('enabled', true);
+    }
+
+    public function testUserCanSkipWhenMFAIsDisabled()
+    {
+        $this->setSiteConfig(['MFARequired' => true]);
+        EnforcementManager::config()->set('enabled', false);
+
+        /** @var Member $member */
+        $member = $this->objFromFixture(Member::class, 'sally_smith');
+        $this->assertTrue(EnforcementManager::create()->canSkipMFA($member));
+    }
+
+    public function testUserCanSkipWhenNoMethodsAreAvailable()
+    {
+        $this->setSiteConfig(['MFARequired' => true]);
+        MethodRegistry::config()->set('methods', null);
+
+        /** @var Member $member */
+        $member = $this->objFromFixture(Member::class, 'sally_smith');
+        $this->assertTrue(EnforcementManager::create()->canSkipMFA($member));
     }
 
     public function testUserWithoutCMSAccessCanSkipWhenCMSAccessIsRequired()


### PR DESCRIPTION
Previously the canSkipMFA method did not validate whether MFA was available, which resulted in a login loop if any other condition stopped the user from skipping, such as MFA being mandated via SiteConfig.

Patches #380 for the 4.0 branch.