### PR TITLE
FIX Reinstate recent translation strings after update

### DIFF
--- a/client/lang/en.js
+++ b/client/lang/en.js
@@ -44,6 +44,8 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "MultiFactorAuthentication.DELETE_CONFIRMATION_BUTTON": "Remove method",
     "MultiFactorAuthentication.RESET_BACKUP_CONFIRMATION": "All existing codes will be made invalid and new codes will be created",
     "MultiFactorAuthentication.RESET_BACKUP_CONFIRMATION_BUTTON": "Reset codes",
-    "MultiFactorAuthentication.ADMIN_SETUP_COMPLETE_CONTINUE": "Your settings have been updated"
+    "MultiFactorAuthentication.ADMIN_SETUP_COMPLETE_CONTINUE": "Your settings have been updated",
+    "MultiFactorAuthentication.TRY_AGAIN_ERROR": "Something went wrong. Please try again.",
+    "MultiFactorAuthentication.UNKNOWN_ERROR": "An unknown error occurred."
 });
 }

--- a/client/lang/src/en.json
+++ b/client/lang/src/en.json
@@ -37,5 +37,7 @@
   "MultiFactorAuthentication.DELETE_CONFIRMATION_BUTTON": "Remove method",
   "MultiFactorAuthentication.RESET_BACKUP_CONFIRMATION": "All existing codes will be made invalid and new codes will be created",
   "MultiFactorAuthentication.RESET_BACKUP_CONFIRMATION_BUTTON": "Reset codes",
-  "MultiFactorAuthentication.ADMIN_SETUP_COMPLETE_CONTINUE": "Your settings have been updated"
+  "MultiFactorAuthentication.ADMIN_SETUP_COMPLETE_CONTINUE": "Your settings have been updated",
+  "MultiFactorAuthentication.TRY_AGAIN_ERROR": "Something went wrong. Please try again.",
+  "MultiFactorAuthentication.UNKNOWN_ERROR": "An unknown error occurred."
 }

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,13 @@ functionality:
 - [Security](docs/en/security.md)
 - [Integrating with other authenticators](docs/en/other-authenticators.md)
 
+## Module development
+
+When adding translatable content to front-end UIs in the MFA module, you must ensure that these translations are pushed
+to Transifex. If this doesn't happen, they will be automatically removed in the next module released. See the
+[translation docs](https://docs.silverstripe.org/en/4/contributing/translation_process/#javascript-translations)
+for more information.
+
 ## License
 
 See [license](LICENSE.md).


### PR DESCRIPTION
We still don't support JS translations in `i18nTextCollector`, so it's up to the developers creating and merging features with new translations to manually update Transifex, otherwise they get trampled during releases.

Once this PR is merged, I'll run the manual push to get Transifex up to date.