### PR TITLE
FIX Provide clearer credit to Simon Erkelens for his contributions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,12 @@
 [![codecov](https://codecov.io/gh/silverstripe/silverstripe-mfa/branch/master/graph/badge.svg)](https://codecov.io/gh/silverstripe/silverstripe-mfa)
 [![SilverStripe supported module](https://img.shields.io/badge/silverstripe-supported-0071C4.svg)](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/)
 
+### With thanks to Simon `Firesphere` Erkelens
+
+This module was based on pioneering work by Simon. It differs from the original implementation in its use of a pluggable
+React UI + JSON API architecture, and its enhanced management UI within the CMS. You can find Simon's original module
+[here](https://github.com/firesphere/silverstripe-mfa).
+
 ## Requirements
 
 * PHP ^7.1


### PR DESCRIPTION
Whilst @firesphere is referenced as an author in the Composer configuration and license for this module, the 'forked' status of the repository was recently removed to reduce toil when raising PRs, which had the unfortunate side effect of masking his original implementation and contributions.

To remedy this, I've added a section to the README describing his involvement and a short description of the differences  between the implementations, and including a link to his original repository.
