### PR TITLE
FIX Correct URL for Simon's original module

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 
 This module was based on pioneering work by Simon. It differs from the original implementation in its use of a pluggable
 React UI + JSON API architecture, and its enhanced management UI within the CMS. You can find Simon's original module
-[here](https://github.com/firesphere/silverstripe-mfa).
+[here](https://github.com/firesphere/silverstripe-bootstrapmfa).
 
 ## Requirements
 


### PR DESCRIPTION
Quick follow-up to #406, to [fix the module URL](https://github.com/silverstripe/silverstripe-mfa/pull/406#issuecomment-692963173).