### PR TITLE
FIX Explicitly disable browser cache on verification response

### DIFF
--- a/src/RequestHandler/VerificationHandlerTrait.php
+++ b/src/RequestHandler/VerificationHandlerTrait.php
@@ -4,6 +4,7 @@ namespace SilverStripe\MFA\RequestHandler;
 
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\MFA\Exception\InvalidMethodException;
 use SilverStripe\MFA\Method\MethodInterface;
@@ -74,6 +75,9 @@ trait VerificationHandlerTrait
         $token = SecurityToken::inst();
         $token->reset();
         $data[$token->getName()] = $token->getValue();
+
+        // Prevent caching of response
+        HTTPCacheControlMiddleware::singleton()->disableCache(true);
 
         // Respond with our method
         return $response->setBody(json_encode($data));

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -6,6 +6,7 @@ use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
@@ -332,6 +333,27 @@ class LoginHandlerTest extends FunctionalTest
 
         $this->assertNotNull($response->SecurityID);
         $this->assertTrue(SecurityToken::inst()->check($response->SecurityID));
+    }
+
+    // This is testing that HTTP caching headers that disable caching are set
+    // in VerificationHandlerTrait::createStartVerificationResponse()
+    // VerificationHandlerTrait is used by LoginHandler
+    public function testStartVerificationHttpCacheHeadersDisabled()
+    {
+        /** @var Member $member */
+        SecurityToken::enable();
+        $handler = new LoginHandler('mfa', $this->createMock(MemberAuthenticator::class));
+        $member = $this->objFromFixture(Member::class, 'robbie');
+        $store = new SessionStore($member);
+        $handler->setStore($store);
+        $request = new HTTPRequest('GET', '/');
+        $request->setSession(new Session([]));
+        $request->setRouteParams(['Method' => 'basic-math']);
+        $middleware = HTTPCacheControlMiddleware::singleton();
+        $middleware->enableCache(true);
+        $this->assertSame('enabled', $middleware->getState());
+        $handler->startVerification($request);
+        $this->assertSame('disabled', $middleware->getState());
     }
 
     public function testVerifyAssertsValidCSRFToken()


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-mfa/issues/414

May fix https://github.com/silverstripe/silverstripe-mfa/issues/393 (untested)
