### PR TITLE
FIX phpunit tests in php8

### DIFF
--- a/tests/php/Authenticator/ChangePasswordHandlerTest.php
+++ b/tests/php/Authenticator/ChangePasswordHandlerTest.php
@@ -16,10 +16,11 @@ use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\MFA\Service\MethodRegistry;
 use SilverStripe\MFA\State\Result;
 use SilverStripe\MFA\Store\SessionStore;
-use SilverStripe\MFA\Store\StoreInterface;
+use SilverStripe\MFA\Tests\Stub\Store\TestStore;
 use SilverStripe\MFA\Tests\Stub\BasicMath\Method;
 use SilverStripe\Security\Member;
 use SilverStripe\SiteConfig\SiteConfig;
+use Test;
 
 class ChangePasswordHandlerTest extends FunctionalTest
 {
@@ -138,7 +139,7 @@ class ChangePasswordHandlerTest extends FunctionalTest
             ->setMethods(['getStore'])
             ->getMock();
 
-        $store = $this->createMock(StoreInterface::class);
+        $store = $this->createMock(TestStore::class);
 
         $handler->expects($this->once())->method('getStore')->willReturn($store);
         $store->expects($this->once())->method('getMember')->willReturn(null);
@@ -155,10 +156,13 @@ class ChangePasswordHandlerTest extends FunctionalTest
             ->setMethods(['getStore', 'createStartVerificationResponse'])
             ->getMock();
 
-        $store = $this->createMock(StoreInterface::class);
+        $store = $this->createMock(TestStore::class);
 
         $handler->expects($this->once())->method('getStore')->willReturn($store);
         $store->expects($this->once())->method('getMember')->willReturn($this->createMock(Member::class));
+
+        // Need to specify willReturn() otherwise mock will attempt to an interface which causes a fatal error in PHP8
+        $store->expects($this->once())->method('save')->willReturn($store);
 
         $expectedResponse = new HTTPResponse();
         $handler->expects($this->once())->method('createStartVerificationResponse')->willReturn($expectedResponse);
@@ -182,7 +186,7 @@ class ChangePasswordHandlerTest extends FunctionalTest
         $logger->expects($this->once())->method('debug');
         $handler->setLogger($logger);
 
-        $store = $this->createMock(StoreInterface::class);
+        $store = $this->createMock(TestStore::class);
 
         $handler->expects($this->once())->method('getStore')->willReturn($store);
         $handler->expects($this->once())->method('completeVerificationRequest')->willThrowException(
@@ -201,7 +205,7 @@ class ChangePasswordHandlerTest extends FunctionalTest
             ->setMethods(['getStore', 'completeVerificationRequest'])
             ->getMock();
 
-        $store = $this->createMock(StoreInterface::class);
+        $store = $this->createMock(TestStore::class);
         $handler->expects($this->once())->method('getStore')->willReturn($store);
 
         $handler->expects($this->once())->method('completeVerificationRequest')->willReturn(
@@ -221,7 +225,7 @@ class ChangePasswordHandlerTest extends FunctionalTest
             ->setMethods(['getStore', 'completeVerificationRequest', 'isVerificationComplete'])
             ->getMock();
 
-        $store = $this->createMock(StoreInterface::class);
+        $store = $this->createMock(TestStore::class);
 
         $handler->expects($this->once())->method('getStore')->willReturn($store);
         $handler->expects($this->once())->method('completeVerificationRequest')->willReturn(new Result());

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -20,7 +20,7 @@ use SilverStripe\MFA\Service\MethodRegistry;
 use SilverStripe\MFA\Service\RegisteredMethodManager;
 use SilverStripe\MFA\State\Result;
 use SilverStripe\MFA\Store\SessionStore;
-use SilverStripe\MFA\Store\StoreInterface;
+use SilverStripe\MFA\Tests\Stub\Store\TestStore;
 use SilverStripe\MFA\Tests\Stub\BasicMath\Method;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\Member;
@@ -382,7 +382,7 @@ class LoginHandlerTest extends FunctionalTest
         $handler = new LoginHandler('mfa', $this->createMock(MemberAuthenticator::class));
         $handler->setRequest(new HTTPRequest('GET', '/'));
         $handler->getRequest()->setSession(new Session([]));
-        $handler->setStore($this->createMock(StoreInterface::class));
+        $handler->setStore($this->createMock(TestStore::class));
 
         $response = $handler->startVerification($handler->getRequest());
         $this->assertSame(403, $response->getStatusCode());

--- a/tests/php/BackupCode/RegisterHandlerTest.php
+++ b/tests/php/BackupCode/RegisterHandlerTest.php
@@ -9,7 +9,7 @@ use SilverStripe\MFA\BackupCode\Method;
 use SilverStripe\MFA\BackupCode\RegisterHandler;
 use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\MFA\Service\RegisteredMethodManager;
-use SilverStripe\MFA\Store\StoreInterface;
+use SilverStripe\MFA\Tests\Stub\Store\TestStore;
 use SilverStripe\MFA\Tests\Stub\BasicMath\Method as BasicMathMethod;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
@@ -24,8 +24,8 @@ class RegisterHandlerTest extends SapphireTest
      */
     public function testStartThrowsExceptionForMemberWithoutRegisteredMethods()
     {
-        /** @var StoreInterface&PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->createMock(StoreInterface::class);
+        /** @var TestStore&PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->createMock(TestStore::class);
 
         /** @var Member&MemberExtension $member */
         $member = $this->objFromFixture(Member::class, 'guy');
@@ -43,8 +43,8 @@ class RegisterHandlerTest extends SapphireTest
         $method = new BasicMathMethod();
         RegisteredMethodManager::singleton()->registerForMember($member, $method, ['need' => 'one']);
 
-        /** @var StoreInterface&PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->createMock(StoreInterface::class);
+        /** @var TestStore&PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->createMock(TestStore::class);
         $store->expects($this->once())->method('getMember')->willReturn($member);
 
         $handler = new RegisterHandler();
@@ -57,8 +57,8 @@ class RegisterHandlerTest extends SapphireTest
 
     public function testStartStoresHashesOfBackupCodesOnMember()
     {
-        /** @var StoreInterface&PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->createMock(StoreInterface::class);
+        /** @var TestStore&PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->createMock(TestStore::class);
 
         /** @var Member&MemberExtension $member */
         $member = $this->objFromFixture(Member::class, 'guy');
@@ -94,8 +94,8 @@ class RegisterHandlerTest extends SapphireTest
 
     public function testRegisterReturnsNoContext()
     {
-        /** @var StoreInterface&PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->createMock(StoreInterface::class);
+        /** @var TestStore&PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->createMock(TestStore::class);
 
         /** @var HTTPRequest|PHPUnit_Framework_MockObject_MockObject $request */
         $request = $this->createMock(HTTPRequest::class);

--- a/tests/php/BackupCode/VerifyHandlerTest.php
+++ b/tests/php/BackupCode/VerifyHandlerTest.php
@@ -9,7 +9,7 @@ use SilverStripe\MFA\BackupCode\VerifyHandler;
 use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\MFA\Model\RegisteredMethod;
 use SilverStripe\MFA\Service\Notification;
-use SilverStripe\MFA\Store\StoreInterface;
+use SilverStripe\MFA\Tests\Stub\Store\TestStore;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
 
@@ -77,8 +77,8 @@ class VerifyHandlerTest extends SapphireTest
         $request = $this->createMock(HTTPRequest::class);
         $request->expects($this->once())->method('getBody')->willReturn("{\"code\":\"{$userInput}\"}");
 
-        /** @var StoreInterface|PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->createMock(StoreInterface::class);
+        /** @var TestStore|PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->createMock(TestStore::class);
         $store->expects($this->any())->method('getMember')->willReturn($member);
 
         /** @var RegisteredMethod $registeredMethod */

--- a/tests/php/BasicMath/MethodVerifyHandlerTest.php
+++ b/tests/php/BasicMath/MethodVerifyHandlerTest.php
@@ -6,7 +6,7 @@ use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\MFA\Model\RegisteredMethod;
-use SilverStripe\MFA\Store\StoreInterface;
+use SilverStripe\MFA\Tests\Stub\Store\TestStore;
 use SilverStripe\MFA\Tests\Stub\BasicMath\MethodVerifyHandler;
 
 class MethodVerifyHandlerTest extends SapphireTest
@@ -15,9 +15,11 @@ class MethodVerifyHandlerTest extends SapphireTest
     {
         $handler = new MethodVerifyHandler();
 
-        /** @var StoreInterface|PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->createMock(StoreInterface::class);
-        $store->expects($this->once())->method('setState');
+        /** @var TestStore|PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->createMock(TestStore::class);
+
+        // Need to specify willReturn() otherwise mock will attempt to an interface which causes a fatal error in PHP8
+        $store->expects($this->once())->method('setState')->willReturn($store);
 
         $mockRegisteredMethod = RegisteredMethod::create();
 
@@ -32,8 +34,8 @@ class MethodVerifyHandlerTest extends SapphireTest
         $request = $this->createMock(HTTPRequest::class);
         $request->expects($this->once())->method('getBody')->willReturn('{"answer":"10"}');
 
-        /** @var StoreInterface|PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->createMock(StoreInterface::class);
+        /** @var TestStore|PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->createMock(TestStore::class);
         $store->expects($this->once())->method('getState')->willReturn([
             'answer' => 10,
         ]);

--- a/tests/php/Stub/Store/TestStore.php
+++ b/tests/php/Stub/Store/TestStore.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\Stub\Store;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\MFA\Store\StoreInterface;
+use SilverStripe\Security\Member;
+
+class TestStore implements StoreInterface, TestOnly
+{
+    public function __construct(Member $member)
+    {
+    }
+
+    public function getMethod(): ?string
+    {
+        return null;
+    }
+
+    public function setMember(Member $member): StoreInterface
+    {
+        return $this;
+    }
+
+    public function setMethod(?string $method): StoreInterface
+    {
+        return $this;
+    }
+
+    public function getState(): array
+    {
+        return [];
+    }
+
+    public function setState(array $state): StoreInterface
+    {
+        return $this;
+    }
+
+    public function addState(array $state): StoreInterface
+    {
+        return $this;
+    }
+
+    public function addVerifiedMethod(string $method): StoreInterface
+    {
+        return $this;
+    }
+
+    public function getVerifiedMethods(): array
+    {
+        return [];
+    }
+
+    public function getMember(): ?Member
+    {
+        return null;
+    }
+
+    public static function clear(HTTPRequest $request): void
+    {
+    }
+
+    public static function load(HTTPRequest $request): ?StoreInterface
+    {
+        return null;
+    }
+
+    public function save(HTTPRequest $request): StoreInterface
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
PHP8 won't allow passing an interface (StoreInterface) to createMock().  Instead we need to mock class.

https://travis-ci.com/github/silverstripe/silverstripe-mfa/jobs/471512031

![image](https://user-images.githubusercontent.com/4809037/104675583-a907f700-574a-11eb-9232-afd6de6a41a1.png)

