### PR TITLE
NEW Disable MFA in dev environments by default

### DIFF
--- a/_config/dev.yml
+++ b/_config/dev.yml
@@ -1,0 +1,7 @@
+---
+Name: mfa-devconfig
+Only:
+  environment: dev
+---
+SilverStripe\MFA\Service\EnforcementManager:
+  enabled: false

--- a/docs/en/local-development.md
+++ b/docs/en/local-development.md
@@ -1,16 +1,17 @@
 # Local development
 
-When running development versions of a project using this module, you may want to disable multi-factor authentication
-while you test other features. You can do this via YAML configuration, for example:
+When running development versions of a project using this module, multi-factor authentication
+is disabled by default.
+
+You can opt back into it via a config setting in your project.
 
 ```yaml
 ---
 Name: mydevconfig
+After: "#mfa-devconfig"
 Only:
   environment: dev
 ---
 SilverStripe\MFA\Service\EnforcementManager:
-  enabled: false
+  enabled: true
 ```
-
-This will not redirect you to multi-factor authentication registration or verification screens when logging in.

--- a/readme.md
+++ b/readme.md
@@ -37,8 +37,9 @@ will be replaced with the MFA authenticator instead. This will provide no change
 an MFA Method has also been configured for the site. The TOTP and WebAuthn modules will configure themselves
 automatically.
 
-After installing the MFA module and having at least one method configured, MFA will automatically be enabled. By default
-it will be optional (users can skip MFA registration). You can make it mandatory via the Settings tab in the admin area.
+After installing the MFA module and having at least one method configured, MFA will automatically be enabled
+in non-dev environments. You can optionally [enable MFA in dev environments](docs/local-development).
+When enabled, users can skip MFA registration. You can make it mandatory via the Settings tab in the admin area.
 
 The MFA flow will only be applied to members with access to the CMS or administration area. See '[Broadening the scope of MFA](docs/en/broadening-the-scope-of-mfa.md)' for more detail.
 

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -16,6 +16,7 @@ use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\MFA\Method\Handler\VerifyHandlerInterface;
 use SilverStripe\MFA\Method\MethodInterface;
 use SilverStripe\MFA\Model\RegisteredMethod;
+use SilverStripe\MFA\Service\EnforcementManager;
 use SilverStripe\MFA\Service\MethodRegistry;
 use SilverStripe\MFA\Service\RegisteredMethodManager;
 use SilverStripe\MFA\State\Result;
@@ -37,6 +38,8 @@ class LoginHandlerTest extends FunctionalTest
     {
         parent::setUp();
         Config::modify()->set(MethodRegistry::class, 'methods', [Method::class]);
+
+        EnforcementManager::config()->set('enabled', true);
 
         Injector::inst()->load([
             Security::class => [


### PR DESCRIPTION
I can't see how that's a good default for anyone,
especially since it also applies to the SS_DEFAULT_ADMIN users
which are very common for local development.

While it's possible for devs to opt-out of this already,
the defaults are the wrong way around in my view.