### PR TITLE
NEW Disable MFA via environment var

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -21,3 +21,10 @@ SilverStripe\Security\Security:
 SilverStripe\MFA\Extension\AccountReset\SecurityExtension:
   extensions:
     mfaResetExtension: SilverStripe\MFA\Extension\AccountReset\MFAResetExtension
+---
+name: mfa-devconfig
+Only:
+  envvarset: 'BYPASS_MFA'
+---
+SilverStripe\MFA\Service\EnforcementManager:
+  enabled: false

--- a/docs/en/local-development.md
+++ b/docs/en/local-development.md
@@ -1,7 +1,15 @@
 # Local development
 
 When running development versions of a project using this module, you may want to disable multi-factor authentication
-while you test other features. You can do this via YAML configuration, for example:
+while you test other features. This will not redirect you to multi-factor authentication registration or verification screens when logging in.
+
+The easiest way is to set an [environment variable](https://docs.silverstripe.org/en/4/developer_guides/configuration/environment_variables/):
+
+```
+BYPASS_MFA=1
+```
+
+Alternatively, YAML configuration affords you more control over the conditions:
 
 ```yaml
 ---
@@ -12,5 +20,3 @@ Only:
 SilverStripe\MFA\Service\EnforcementManager:
   enabled: false
 ```
-
-This will not redirect you to multi-factor authentication registration or verification screens when logging in.

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,9 @@ it will be optional (users can skip MFA registration). You can make it mandatory
 
 The MFA flow will only be applied to members with access to the CMS or administration area. See '[Broadening the scope of MFA](docs/en/broadening-the-scope-of-mfa.md)' for more detail.
 
+You can disable MFA on an environment by setting a `BYPASS_MFA=1` environment variable,
+or via YAML config - see [local development](docs/en/local-development) for details.
+
 ### Configuring custom methods
 
 If you have built your own MFA method, you can register it with the `MethodRegistry` to enable it:

--- a/tests/php/Authenticator/LoginHandlerTest.php
+++ b/tests/php/Authenticator/LoginHandlerTest.php
@@ -16,6 +16,7 @@ use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\MFA\Method\Handler\VerifyHandlerInterface;
 use SilverStripe\MFA\Method\MethodInterface;
 use SilverStripe\MFA\Model\RegisteredMethod;
+use SilverStripe\MFA\Service\EnforcementManager;
 use SilverStripe\MFA\Service\MethodRegistry;
 use SilverStripe\MFA\Service\RegisteredMethodManager;
 use SilverStripe\MFA\State\Result;
@@ -37,6 +38,8 @@ class LoginHandlerTest extends FunctionalTest
     {
         parent::setUp();
         Config::modify()->set(MethodRegistry::class, 'methods', [Method::class]);
+
+        EnforcementManager::config()->set('enabled', true);
 
         Injector::inst()->load([
             Security::class => [


### PR DESCRIPTION
The YAML configuration is a bit too clunky.
Raised the visibility of this (extremely common) need for devs in the README,
rather than hiding it away in a "local development" section.

Replaces https://github.com/silverstripe/silverstripe-mfa/pull/419