### PR TITLE
FIX Disable HTTP caching on all relevant MFA API endpoints

### DIFF
--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -7,6 +7,7 @@ namespace SilverStripe\MFA\Authenticator;
 use Psr\Log\LoggerInterface;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\MFA\Exception\InvalidMethodException;
 use SilverStripe\MFA\Exception\MemberNotFoundException;
@@ -159,9 +160,13 @@ class LoginHandler extends BaseLoginHandler
      */
     public function getSchema(): HTTPResponse
     {
+        // Prevent caching of response
+        HTTPCacheControlMiddleware::singleton()->disableCache(true);
+
         try {
             $member = $this->getMember();
             $schema = SchemaGenerator::create()->getSchema($member);
+
             return $this->jsonResponse(
                 $schema + [
                     'endpoints' => [
@@ -186,6 +191,9 @@ class LoginHandler extends BaseLoginHandler
      */
     public function startRegistration(HTTPRequest $request): HTTPResponse
     {
+        // Prevent caching of response
+        HTTPCacheControlMiddleware::singleton()->disableCache(true);
+
         $store = $this->getStore();
         $sessionMember = $store ? $store->getMember() : null;
         $loggedInMember = Security::getCurrentUser();
@@ -344,6 +352,9 @@ class LoginHandler extends BaseLoginHandler
      */
     public function startVerification(HTTPRequest $request): HTTPResponse
     {
+        // Prevent caching of response
+        HTTPCacheControlMiddleware::singleton()->disableCache(true);
+
         $store = $this->getStore();
         // If we don't have a valid member we shouldn't be here, or if sudo mode is not active yet.
         if (!$store || !$store->getMember() || !$this->getSudoModeService()->check($request->getSession())) {

--- a/src/Controller/AdminRegistrationController.php
+++ b/src/Controller/AdminRegistrationController.php
@@ -8,6 +8,7 @@ use Psr\Log\LoggerInterface;
 use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\MFA\Extension\MemberExtension;
 use SilverStripe\MFA\RequestHandler\BaseHandlerTrait;
@@ -66,6 +67,9 @@ class AdminRegistrationController extends LeftAndMain
      */
     public function startRegistration(HTTPRequest $request): HTTPResponse
     {
+        // Prevent caching of response
+        HTTPCacheControlMiddleware::singleton()->disableCache(true);
+
         // Create a fresh store from the current logged in user
         $member = Security::getCurrentUser();
         $store = $this->createStore($member);

--- a/src/RequestHandler/VerificationHandlerTrait.php
+++ b/src/RequestHandler/VerificationHandlerTrait.php
@@ -4,7 +4,6 @@ namespace SilverStripe\MFA\RequestHandler;
 
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\MFA\Exception\InvalidMethodException;
 use SilverStripe\MFA\Method\MethodInterface;
@@ -75,9 +74,6 @@ trait VerificationHandlerTrait
         $token = SecurityToken::inst();
         $token->reset();
         $data[$token->getName()] = $token->getValue();
-
-        // Prevent caching of response
-        HTTPCacheControlMiddleware::singleton()->disableCache(true);
 
         // Respond with our method
         return $response->setBody(json_encode($data));

--- a/tests/php/Controller/AdminRegistrationControllerTest.php
+++ b/tests/php/Controller/AdminRegistrationControllerTest.php
@@ -7,6 +7,7 @@ use Psr\Log\LoggerInterface;
 use SilverStripe\Admin\AdminRootController;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\FunctionalTest;
@@ -82,6 +83,19 @@ class AdminRegistrationControllerTest extends FunctionalTest
         );
 
         $this->assertSame(200, $result->getStatusCode());
+    }
+
+    /**
+     * Test that HTTP caching is disabled in requests to the registration endpoint
+     */
+    public function testStartRegistrationDisablesHTTPCaching()
+    {
+        $middleware = HTTPCacheControlMiddleware::singleton();
+        $middleware->enableCache(true);
+        $this->assertSame('enabled', $middleware->getState());
+
+        $this->get(Controller::join_links(AdminRootController::admin_url(), 'mfa', 'register/foo'));
+        $this->assertSame('disabled', $middleware->getState());
     }
 
     public function testFinishRegistrationGracefullyHandlesInvalidSessions()


### PR DESCRIPTION
Follow up to #417, applying the cache configuration to schema fetching and registration initialisation in both the main MFA UI and the Profile UI.

Fixes #393.