### PR TITLE
FIX Export registered methods in enabled members report

### DIFF
--- a/src/Exception/AuthenticationFailedException.php
+++ b/src/Exception/AuthenticationFailedException.php
@@ -6,5 +6,4 @@ use Exception;
 
 class AuthenticationFailedException extends Exception
 {
-
 }

--- a/src/Exception/EncryptionAdapterException.php
+++ b/src/Exception/EncryptionAdapterException.php
@@ -9,5 +9,4 @@ use Exception;
  */
 class EncryptionAdapterException extends Exception
 {
-
 }

--- a/src/Exception/InvalidMethodException.php
+++ b/src/Exception/InvalidMethodException.php
@@ -6,5 +6,4 @@ use LogicException;
 
 class InvalidMethodException extends LogicException
 {
-
 }

--- a/src/Exception/MemberNotFoundException.php
+++ b/src/Exception/MemberNotFoundException.php
@@ -9,5 +9,4 @@ use Exception;
  */
 class MemberNotFoundException extends Exception
 {
-
 }

--- a/src/Exception/RegistrationFailedException.php
+++ b/src/Exception/RegistrationFailedException.php
@@ -6,5 +6,4 @@ use LogicException;
 
 class RegistrationFailedException extends LogicException
 {
-
 }

--- a/src/Extension/MemberExtension.php
+++ b/src/Extension/MemberExtension.php
@@ -69,6 +69,26 @@ class MemberExtension extends DataExtension implements PermissionProvider
         return $this->owner;
     }
 
+    /**
+     * @return string
+     */
+    public function getDefaultRegisteredMethodName(): string
+    {
+        $method = $this->getDefaultRegisteredMethod();
+        return $method ? $method->getMethod()->getName() : '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getRegisteredMethodNames(): string
+    {
+        $arr = array_map(function ($method) {
+            return $method->getMethod()->getName();
+        }, $this->owner->RegisteredMFAMethods()->toArray());
+        return implode(', ', $arr);
+    }
+
     public function updateCMSFields(FieldList $fields): FieldList
     {
         $fields->removeByName(['DefaultRegisteredMethodID', 'HasSkippedMFARegistration', 'RegisteredMFAMethods']);

--- a/src/Report/EnabledMembers.php
+++ b/src/Report/EnabledMembers.php
@@ -94,13 +94,11 @@ class EnabledMembers extends Report
     public function columns(): array
     {
         $columns = singleton(Member::class)->summaryFields() + [
-            'registeredMethods' => [
-                'title' => _t(__CLASS__ . '.COLUMN_METHODS_REGISTERED', 'Registered methods'),
-                'formatting' => [$this, 'formatMethodsColumn']
+            'RegisteredMethodNames' => [
+                'title' => _t(__CLASS__ . '.COLUMN_METHODS_REGISTERED', 'Registered methods')
             ],
-            'defaultMethodName' => [
-                'title' => _t(__CLASS__ . '.COLUMN_METHOD_DEFAULT', 'Default method'),
-                'formatting' => [$this, 'formatDefaultMethodColumn']
+            'DefaultRegisteredMethodName' => [
+                'title' => _t(__CLASS__ . '.COLUMN_METHOD_DEFAULT', 'Default method')
             ],
             'HasSkippedMFARegistration' => [
                 'title' => _t(__CLASS__ . '.COLUMN_SKIPPED_REGISTRATION', 'Skipped registration'),
@@ -153,6 +151,7 @@ class EnabledMembers extends Report
      * @param null $_
      * @param Member $record
      * @return string
+     * @deprecated Will be removed in 5.0 use MemberExtension::getRegisteredMethodNames() instead
      */
     public function formatMethodsColumn($_, Member $record): string
     {
@@ -170,6 +169,7 @@ class EnabledMembers extends Report
      * @param null $_
      * @param Member&MemberExtension $record
      * @return string
+     * @deprecated Will be removed in 5.0 use MemberExtension::getDefaultRegisteredMethodName() instead
      */
     public function formatDefaultMethodColumn($_, Member $record): string
     {

--- a/src/State/AvailableMethodDetailsInterface.php
+++ b/src/State/AvailableMethodDetailsInterface.php
@@ -10,5 +10,4 @@ use JsonSerializable;
  */
 interface AvailableMethodDetailsInterface extends JsonSerializable
 {
-
 }

--- a/src/State/RegisteredMethodDetailsInterface.php
+++ b/src/State/RegisteredMethodDetailsInterface.php
@@ -10,5 +10,4 @@ use JsonSerializable;
  */
 interface RegisteredMethodDetailsInterface extends JsonSerializable
 {
-
 }

--- a/tests/php/Extension/MemberExtensionTest.php
+++ b/tests/php/Extension/MemberExtensionTest.php
@@ -70,4 +70,27 @@ class MemberExtensionTest extends SapphireTest
         $anotherMember = $this->objFromFixture(Member::class, 'squib');
         $anotherMember->setDefaultRegisteredMethod($registeredMethod);
     }
+
+    public function testGetDefaultRegisteredMethodName()
+    {
+        $member = $this->createMemberWithRegisteredMethods();
+        $this->assertSame('Recovery codes', $member->getDefaultRegisteredMethodName());
+    }
+
+    public function testGetRegisteredMethodNames()
+    {
+        $member = $this->createMemberWithRegisteredMethods();
+        $this->assertSame('Recovery codes, MemberExtensionTestMethod2', $member->getRegisteredMethodNames());
+    }
+
+    private function createMemberWithRegisteredMethods(): Member
+    {
+        $manager = RegisteredMethodManager::singleton();
+        $member = $this->objFromFixture(Member::class, 'squib');
+        $method = new Method();
+        $method2 = new MemberExtensionTestMethod2();
+        $manager->registerForMember($member, $method, ['foo' => 'bar']);
+        $manager->registerForMember($member, $method2, ['abc' => 'xyz']);
+        return $member;
+    }
 }

--- a/tests/php/Extension/MemberExtensionTestMethod2.php
+++ b/tests/php/Extension/MemberExtensionTestMethod2.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SilverStripe\MFA\Tests\Extension;
+
+use SilverStripe\MFA\BackupCode\Method;
+
+/**
+ * This needs to be a separate class rather than an anonymous class
+ * because Injector in php 7.3 doesn't work with an anonmyous classes
+ * in this context
+ */
+class MemberExtensionTestMethod2 extends Method
+{
+    public function getName(): string
+    {
+        return 'MemberExtensionTestMethod2';
+    }
+    public function getURLSegment(): string
+    {
+        return 'MemberExtensionTestMethod2';
+    }
+}

--- a/tests/php/Stub/DuplicatedBasicMath/Method.php
+++ b/tests/php/Stub/DuplicatedBasicMath/Method.php
@@ -9,5 +9,4 @@ use SilverStripe\MFA\Tests\Stub\BasicMath\Method as BasicMathMethod;
  */
 class Method extends BasicMathMethod
 {
-
 }

--- a/tests/php/Stub/Null/RegisterHandler.php
+++ b/tests/php/Stub/Null/RegisterHandler.php
@@ -10,7 +10,6 @@ use SilverStripe\MFA\Store\StoreInterface;
 
 class RegisterHandler implements RegisterHandlerInterface, TestOnly
 {
-
     /**
      * Stores any data required to handle a registration process with a method, and returns relevant state to be applied
      * to the front-end application managing the process.


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-mfa/issues/443

GridFieldExportButton doesn't apply formatting.  I actually try fixing it that way first [here](https://github.com/silverstripe/silverstripe-framework/pull/10202) before realizing this is probably bad because the exported data may included HTML link hyperlinks which will looks really bad in a csv

So I think the proper solution is don't manipulate data in a formatting function, instead just create some new 'get' methods that do the data manipulation

Also fixed some phpcs issues