### PR TITLE
DEP Set PHP 7.4 as the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "silverstripe/framework": "^4.10",
         "silverstripe/admin": "^1.1",
         "silverstripe/siteconfig": "^4.1",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10219
