### PR TITLE
MNT Fix unit test

### DIFF
--- a/tests/php/Controller/AdminRegistrationControllerTest.php
+++ b/tests/php/Controller/AdminRegistrationControllerTest.php
@@ -93,6 +93,7 @@ class AdminRegistrationControllerTest extends FunctionalTest
      */
     public function testStartRegistrationDisablesHTTPCaching()
     {
+        $this->logInAs($this->objFromFixture(Member::class, 'sally_smith'));
         $middleware = HTTPCacheControlMiddleware::singleton();
         $middleware->enableCache(true);
         $this->assertSame('enabled', $middleware->getState());


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10278

Travis error https://app.travis-ci.com/github/silverstripe/recipe-kitchen-sink/jobs/567740349#L1927

This unit test wasn't actually testing what it was supposed to.  Previously it was just going to the /Security/login. Changed so it logs in a mock user like all the other tests in the file so that it actually reaches the line of code it's testing `AdminRegistrationController::startRegistration() ... HTTPCacheControlMiddleware::singleton()->disableCache(true);`