### PR TITLE
Recovery code remove spaces

### DIFF
--- a/src/BackupCode/VerifyHandler.php
+++ b/src/BackupCode/VerifyHandler.php
@@ -67,7 +67,7 @@ class VerifyHandler implements VerifyHandlerInterface
             );
         }
 
-        $code = $bodyJSON['code'];
+        $code = str_replace(' ', '', $bodyJSON['code']);
 
         $candidates = json_decode($registeredMethod->Data ?? '', true);
 

--- a/tests/php/BackupCode/VerifyHandlerTest.php
+++ b/tests/php/BackupCode/VerifyHandlerTest.php
@@ -65,6 +65,7 @@ class VerifyHandlerTest extends SapphireTest
             [false, null, 'Null input is handled'],
             [false, str_pad('', 10000, 'code'), 'Long codes are handled'],
             [true, '123456', 'Valid codes are valid'],
+            [true, '123 456', 'Spaces are stripped out'],
         ];
     }
 


### PR DESCRIPTION
#435 Recovery codes strip characters that don't match the "A-Za-z0-9" characters and replace with empty string.