### PR TITLE
FIX  phpdoc for better symbols resolving

### DIFF
--- a/src/Extension/AccountReset/MemberExtension.php
+++ b/src/Extension/AccountReset/MemberExtension.php
@@ -15,9 +15,9 @@ use SilverStripe\Security\RandomGenerator;
  * Provides DB columns / methods for account resets on Members
  *
  * @package SilverStripe\MFA\Extension
- * @property Member&MemberExtension owner
- * @property string AccountResetHash
- * @property DBDatetime AccountResetExpired
+ * @property Member&MemberExtension $owner
+ * @property string $AccountResetHash
+ * @property DBDatetime $AccountResetExpired
  */
 class MemberExtension extends DataExtension
 {

--- a/src/Extension/AccountReset/SecurityExtension.php
+++ b/src/Extension/AccountReset/SecurityExtension.php
@@ -26,7 +26,7 @@ use SilverStripe\Security\Security;
  * additional authentication factors, sending alerts, etc.)
  *
  * @package SilverStripe\MFA\Extension
- * @property Security owner
+ * @property Security $owner
  */
 class SecurityExtension extends Extension
 {

--- a/src/Extension/MemberExtension.php
+++ b/src/Extension/MemberExtension.php
@@ -21,11 +21,11 @@ use SilverStripe\Security\Security;
 /**
  * Extend Member to add relationship to registered methods and track some specific preferences
  *
- * @method RegisteredMethod[]|HasManyList RegisteredMFAMethods
- * @property MethodInterface DefaultRegisteredMethod
- * @property string DefaultRegisteredMethodID
- * @property bool HasSkippedMFARegistration
- * @property Member|MemberExtension owner
+ * @method RegisteredMethod[]|HasManyList RegisteredMFAMethods()
+ * @property MethodInterface $DefaultRegisteredMethod
+ * @property string $DefaultRegisteredMethodID
+ * @property bool $HasSkippedMFARegistration
+ * @property Member|MemberExtension $owner
  */
 class MemberExtension extends DataExtension implements PermissionProvider
 {

--- a/src/Extension/SiteConfigExtension.php
+++ b/src/Extension/SiteConfigExtension.php
@@ -14,8 +14,8 @@ use SilverStripe\View\Requirements;
 /**
  * Adds multi-factor authentication related settings to the SiteConfig "Access" tab
  *
- * @property bool MFARequired
- * @property string MFAGracePeriodExpires
+ * @property bool $MFARequired
+ * @property string $MFAGracePeriodExpires
  */
 class SiteConfigExtension extends DataExtension
 {

--- a/src/Model/RegisteredMethod.php
+++ b/src/Model/RegisteredMethod.php
@@ -14,10 +14,10 @@ use SilverStripe\Security\Member;
 /**
  * @package SilverStripe\MFA\Model
  *
- * @property int ID
- * @property string MethodClassName
- * @property string Data
- * @method Member Member
+ * @property int $ID
+ * @property string $MethodClassName
+ * @property string $Data
+ * @method Member Member()
  */
 class RegisteredMethod extends DataObject
 {


### PR DESCRIPTION
PHPSTAN cannot resolve the methods and properties in this module's extensions because they lack dollar sign before the properties' names and brackets after methods' names.