### PR TITLE
FIX Add back in sudo mode activation on login

### DIFF
--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -98,6 +98,10 @@ class LoginHandler extends BaseLoginHandler
             return parent::doLogin($data, $form, $request);
         }
 
+        // We need to call getSudoModeService()->activate() here otherwise the check in
+        // mfa() to getSudoModeService()->check($request->getSession()) will fail
+        $this->getSudoModeService()->activate($request->getSession());
+
         // Create a store for handling MFA for this member
         $store = $this->createStore($member);
         // We don't need to store the user's password


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-mfa/issues/483

Was removed [here](https://github.com/silverstripe/silverstripe-mfa/pull/482/files#diff-5800f875a776e201bdea90a86e3d9a0c5d18bfde1929240700d4d95b65a50293L102) 

We need this because the check in `LoginHandler::mfa()` .. `$this->getSudoModeService()->check($request->getSession())` will fail if we don't have this