### PR TITLE
DEP Bump minimum version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.13",
         "silverstripe/admin": "^1.1",
         "silverstripe/siteconfig": "^4.1",
         "defuse/php-encryption": "^2.2",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Failing on Deprecation::isEnabled() on --prefer-lowest build

https://github.com/silverstripe/silverstripe-mfa/actions/runs/9851675052