### PR TITLE
MNT Ignore lint failure we can't fix yet

### DIFF
--- a/src/RequestHandler/RegistrationHandlerTrait.php
+++ b/src/RequestHandler/RegistrationHandlerTrait.php
@@ -46,6 +46,7 @@ trait RegistrationHandlerTrait
             ->addHeader('Content-Type', 'application/json');
 
         if (!$allowReregistration && $existingRegisteredMethod) {
+            /** @phpstan-ignore translation.key (we can't change this to __TRAIT__ until the next major release) */
             return $response->setBody(json_encode(['errors' => [_t(
                 __CLASS__ . '.METHOD_ALREADY_REGISTERED',
                 'That method has already been registered against this Member'
@@ -80,6 +81,7 @@ trait RegistrationHandlerTrait
         HTTPRequest $request
     ): Result {
         if (!SecurityToken::inst()->checkRequest($request)) {
+            /** @phpstan-ignore translation.key (we can't change this to __TRAIT__ until the next major release) */
             return Result::create(false, _t(
                 __CLASS__ . '.CSRF_FAILURE',
                 'Your request timed out. Please refresh and try again'
@@ -90,6 +92,7 @@ trait RegistrationHandlerTrait
 
         // If a registration process hasn't been initiated in a previous request, calling this method is invalid
         if (!$storedMethodName) {
+            /** @phpstan-ignore translation.key (we can't change this to __TRAIT__ until the next major release) */
             return Result::create(false, _t(__CLASS__ . '.NO_REGISTRATION_IN_PROGRESS', 'No registration in progress'));
         }
 
@@ -97,6 +100,7 @@ trait RegistrationHandlerTrait
         if ($storedMethodName !== $method->getURLSegment()) {
             return Result::create(
                 false,
+                /** @phpstan-ignore translation.key (we can't change this to __TRAIT__ until the next major release) */
                 _t(__CLASS__ . '.METHOD_MISMATCH', 'Method does not match registration in progress')
             );
         }

--- a/src/RequestHandler/VerificationHandlerTrait.php
+++ b/src/RequestHandler/VerificationHandlerTrait.php
@@ -54,11 +54,13 @@ trait VerificationHandlerTrait
         if (!$registeredMethod) {
             // We can display a specific message if there was no method specified
             if (!$requestedMethod) {
+                /** @phpstan-ignore translation.key (we can't change this to __TRAIT__ until the next major release) */
                 $message = _t(
                     __CLASS__ . '.METHOD_NOT_PROVIDED',
                     'No method was provided to login with and the Member has no default'
                 );
             } else {
+                /** @phpstan-ignore translation.key (we can't change this to __TRAIT__ until the next major release) */
                 $message = _t(__CLASS__ . '.METHOD_NOT_REGISTERED', 'Member does not have this method registered');
             }
 
@@ -90,6 +92,7 @@ trait VerificationHandlerTrait
     protected function completeVerificationRequest(StoreInterface $store, HTTPRequest $request): Result
     {
         if (!SecurityToken::inst()->checkRequest($request)) {
+            /** @phpstan-ignore translation.key (we can't change this to __TRAIT__ until the next major release) */
             return Result::create(false, _t(
                 __CLASS__ . '.CSRF_FAILURE',
                 'Your request timed out. Please refresh and try again'


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-mfa/actions/runs/10278330127/job/28442156742
> Can't determine value of first argument to _t(). Use a simpler value. 

After this has been merged, I'll open a PR for CMS 6 to change `__CLASS__` here to `__TRAIT__` instead. There's no reason for these to be per-class, and the text collector knows how to handle `__TRAIT__` so it won't cause problems there.

## Issue
- https://github.com/silverstripe/.github/issues/290