### PR TITLE
FIX Drop already-verified check from SessionStore

### DIFF
--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -114,10 +114,6 @@ class SessionStore implements StoreInterface
      */
     public function setMethod(?string $method): StoreInterface
     {
-        if (in_array($method, $this->getVerifiedMethods() ?? [])) {
-            throw new InvalidMethodException('You cannot verify with a method you have already verified');
-        }
-
         $this->method = $method;
 
         return $this;

--- a/tests/php/Store/SessionStoreTest.php
+++ b/tests/php/Store/SessionStoreTest.php
@@ -25,15 +25,6 @@ class SessionStoreTest extends SapphireTest
         $this->assertSame(['foo' => 'baz', 'bar' => 'baz'], $store->getState());
     }
 
-    public function testSetMethodWithVerifiedMethod()
-    {
-        $this->expectException(\SilverStripe\MFA\Exception\InvalidMethodException::class);
-        $this->expectExceptionMessage('You cannot verify with a method you have already verified');
-        $store = new SessionStore($this->createMock(Member::class));
-        $store->addVerifiedMethod('foobar');
-        $store->setMethod('foobar');
-    }
-
     public function testSetMethod()
     {
         $store = new SessionStore($this->createMock(Member::class));


### PR DESCRIPTION


<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description

While ostensibly a useful safety check, this validation step is superfluous. The purpose of SessionStore is to hold context for the verification process, not to verify its integrity, and there exist (extremely hard-to-reproduce) edge-cases where this will unhelpfully break the MFA flow.

The MFA method verification process is sufficiently idempotent and safe to prevent any negative outcomes from a method being verified multiple times in a single MFA flow.

## Manual testing steps

See reproduction steps in related issue.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #589 

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
