### PR TITLE
DEP Add conflict with older versions of silverstripe/admin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "phpstan/extension-installer": "^1.3"
     },
     "conflict": {
+        "silverstripe/admin": "<2.4.0",
         "silverstripe/subsites": "<2.2.2 || 2.3.0",
         "silverstripe/webauthn-authenticator": "<4.5.0"
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1898

Since we stopped using the HOC on the mfa field, we should prevent installing this will older versions of admin which won't add the new sudo mode password field