### PR TITLE
ENH Use ConfirmPasswordField to show password strength

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/admin": "^3",
         "silverstripe/siteconfig": "^6",
         "defuse/php-encryption": "^2.4",

--- a/src/Extension/AccountReset/SecurityExtension.php
+++ b/src/Extension/AccountReset/SecurityExtension.php
@@ -11,12 +11,10 @@ use SilverStripe\Core\Extension;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
-use SilverStripe\Forms\PasswordField;
-use SilverStripe\Forms\Validation\RequiredFieldsValidator;
-use SilverStripe\MFA\JSONResponse;
 use SilverStripe\MFA\RequestHandler\BaseHandlerTrait;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Forms\ConfirmedPasswordField;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 
@@ -102,33 +100,23 @@ class SecurityExtension extends Extension
 
     public function ResetAccountForm(): Form
     {
+        $field = ConfirmedPasswordField::create(
+            'Password',
+            _t(Member::class . '.NEWPASSWORD', 'New Password'),
+            '',
+            null,
+            false,
+            _t(Member::class . '.CONFIRMNEWPASSWORD', 'Confirm New Password')
+        );
+        $field->setIsOnMemberForm(true);
         $fields = FieldList::create([
-            PasswordField::create(
-                'NewPassword1',
-                _t(
-                    'SilverStripe\\Security\\Member.NEWPASSWORD',
-                    'New password'
-                )
-            ),
-            PasswordField::create(
-                'NewPassword2',
-                _t(
-                    'SilverStripe\\Security\\Member.CONFIRMNEWPASSWORD',
-                    'Confirm new password'
-                )
-            ),
+            $field,
         ]);
-
         $actions = FieldList::create([
             FormAction::create('doResetAccount', 'Reset account'),
         ]);
-
-        $validation = RequiredFieldsValidator::create(['NewPassword1', 'NewPassword2']);
-
-        $form = Form::create($this->owner, 'ResetAccountForm', $fields, $actions, $validation);
-
+        $form = Form::create($this->owner, 'ResetAccountForm', $fields, $actions);
         $this->owner->extend('updateResetAccountForm', $form);
-
         return $form;
     }
 
@@ -158,22 +146,10 @@ class SecurityExtension extends Extension
 
         /** @var Member&MemberExtension $member */
         $member = Member::get()->byID((int) $memberID);
-
-        // Fail if passwords do not match
-        if ($data['NewPassword1'] !== $data['NewPassword2']) {
-            $form->sessionMessage(
-                _t(
-                    'SilverStripe\\Security\\Member.ERRORNEWPASSWORD',
-                    'You have entered your new password differently, try again'
-                ),
-                ValidationResult::TYPE_ERROR
-            );
-
-            return $this->owner->redirectBack();
-        }
+        $password = $data['Password']['_Password'] ?? null;
 
         // Check if the new password is accepted
-        $validationResult = $member->changePassword($data['NewPassword1']);
+        $validationResult = $member->changePassword($password);
         if (!$validationResult->isValid()) {
             $form->setSessionValidationResult($validationResult);
 

--- a/tests/php/Authenticator/ChangePasswordHandlerTest.php
+++ b/tests/php/Authenticator/ChangePasswordHandlerTest.php
@@ -71,7 +71,7 @@ class ChangePasswordHandlerTest extends FunctionalTest
     {
         $this->logInAs('simon');
         $response = $this->get('Security/changepassword');
-        $this->assertStringContainsString('OldPassword', $response->getBody());
+        $this->assertStringContainsString('Password[_CurrentPassword]', $response->getBody());
     }
 
     public function testMFADoesNotLoadWhenAUserDoesNotHaveRegisteredMethods()
@@ -82,9 +82,13 @@ class ChangePasswordHandlerTest extends FunctionalTest
         $token = $member->generateAutologinTokenAndStoreHash();
         $response = $this->get("Security/changepassword?m={$memberId}&t={$token}");
 
-        $this->assertStringContainsString('NewPassword1', $response->getBody(), 'There should be a new password field');
         $this->assertStringContainsString(
-            'NewPassword2',
+            'Password[_Password]',
+            $response->getBody(),
+            'There should be a new password field'
+        );
+        $this->assertStringContainsString(
+            'Password[_ConfirmPassword]',
             $response->getBody(),
             'There should be a confirm new password field'
         );

--- a/tests/php/Extension/AccountReset/SecurityExtensionTest.php
+++ b/tests/php/Extension/AccountReset/SecurityExtensionTest.php
@@ -8,6 +8,8 @@ use SilverStripe\MFA\Extension\AccountReset\MemberExtension;
 use SilverStripe\MFA\Extension\AccountReset\SecurityAdminExtension;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Validation\PasswordValidator;
+use SilverStripe\Security\Validation\RulesPasswordValidator;
 
 /**
  * Class SecurityExtensionTest
@@ -18,17 +20,22 @@ class SecurityExtensionTest extends FunctionalTest
 {
     protected static $fixture_file = 'SecurityExtensionTest.yml';
 
+    private ?PasswordValidator $origValidator;
+
     protected function setUp(): void
     {
         parent::setUp();
+        $this->origValidator = Member::password_validator();
+        $validator = (new RulesPasswordValidator())
+            ->setMinLength(6)
+            ->setMinTestScore(1);
+        Member::set_password_validator($validator);
+    }
 
-        $validator = Member::password_validator();
-        // Do not let project code rules for password strength break these tests
-        if ($validator) {
-            $validator
-                ->setMinLength(6)
-                ->setMinTestScore(1);
-        }
+    protected function tearDown(): void
+    {
+        Member::set_password_validator($this->origValidator);
+        parent::tearDown();
     }
 
     public function testResetAccountFailsWhenAlreadyAuthenticated()
@@ -93,7 +100,10 @@ class SecurityExtensionTest extends FunctionalTest
         $response = $this->submitForm(
             'Form_ResetAccountForm',
             null,
-            ['NewPassword1' => 'testtest', 'NewPassword2' => 'testtest']
+            [
+                'Password[_Password]' => 'testtest',
+                'Password[_ConfirmPassword]' => 'testtest',
+            ],
         );
 
         $this->assertStringContainsString('The account reset process timed out', $response->getBody());
@@ -113,7 +123,10 @@ class SecurityExtensionTest extends FunctionalTest
         $response = $this->submitForm(
             'Form_ResetAccountForm',
             null,
-            ['NewPassword1' => 'testtest', 'NewPassword2' => 'testtest']
+            [
+                'Password[_Password]' => 'testtest',
+                'Password[_ConfirmPassword]' => 'testtest',
+            ],
         );
 
         // User should have been redirected to Login form with session message


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11475

The account reset form is available by:
- Logging in as an admin
- Create a new member
- In the MFA section of the member edit form, reset their account
- In a different browser, click the email link

That form uses login-forms