### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/src/Extension/AccountReset/MemberExtension.php
+++ b/src/Extension/AccountReset/MemberExtension.php
@@ -48,9 +48,7 @@ class MemberExtension extends Extension
             $token = $generator->randomToken();
             $hash = $this->owner->encryptWithUserSettings($token);
         } while (
-            DataObject::get_one(Member::class, [
-            '"Member"."AccountResetHash"' => $hash,
-            ])
+            Member::get()->setUseCache(true)->find('AccountResetHash', $hash)
         );
 
         $this->owner->AccountResetHash = $hash;

--- a/src/FormField/RegisteredMFAMethodListField.php
+++ b/src/FormField/RegisteredMFAMethodListField.php
@@ -46,7 +46,7 @@ class RegisteredMFAMethodListField extends FormField
         if (!$this->value && $this->getForm() && $this->getForm()->getRecord() instanceof Member) {
             $member = $this->getForm()->getRecord();
         } else {
-            $member = DataObject::get_by_id(Member::class, $this->value);
+            $member = Member::get()->setUseCache(true)->byID($this->value);
         }
 
         return array_merge($defaults, [

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -71,7 +71,7 @@ class SessionStore implements StoreInterface
     public function getMember(): ?Member
     {
         if (!$this->member && $this->memberID) {
-            $this->member = DataObject::get_by_id(Member::class, $this->memberID);
+            $this->member = Member::get()->setUseCache(true)->byID($this->memberID);
         }
 
         return $this->member;

--- a/tests/php/BackupCode/VerifyHandlerTest.php
+++ b/tests/php/BackupCode/VerifyHandlerTest.php
@@ -44,7 +44,7 @@ class VerifyHandlerTest extends SapphireTest
         list ($request, $store, $method) = $this->scaffoldVerifyParams('123456');
         $this->assertTrue($handler->verify($request, $store, $method)->isSuccessful());
 
-        $method = DataObject::get_by_id(RegisteredMethod::class, $method->ID);
+        $method = RegisteredMethod::get()->setUseCache(true)->byID($method->ID);
         $codes = json_decode($method->Data ?? '', true);
 
         $this->assertCount(3, $codes, 'Only 3 codes remain against the method');

--- a/tests/php/Service/RegisteredMethodManagerTest.php
+++ b/tests/php/Service/RegisteredMethodManagerTest.php
@@ -184,8 +184,8 @@ class RegisteredMethodManagerTest extends SapphireTest
 
         $this->assertCount(0, $member->RegisteredMFAMethods());
 
-        $this->assertNull(DataObject::get_by_id(RegisteredMethod::class, $backupMethod->ID));
-        $this->assertNull(DataObject::get_by_id(RegisteredMethod::class, $mathMethod->ID));
+        $this->assertNull(RegisteredMethod::get()->setUseCache(true)->byID($backupMethod->ID));
+        $this->assertNull(RegisteredMethod::get()->setUseCache(true)->byID($mathMethod->ID));
     }
 
     public function testCanRemoveTheOnlyMethodWhenMFAIsOptional()


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
