### PR TITLE
ENH Optimise SQL queries to improve performance

### DIFF
--- a/src/Extension/AccountReset/MemberExtension.php
+++ b/src/Extension/AccountReset/MemberExtension.php
@@ -48,7 +48,7 @@ class MemberExtension extends Extension
             $token = $generator->randomToken();
             $hash = $this->owner->encryptWithUserSettings($token);
         } while (
-            Member::get()->setUseCache(true)->find('AccountResetHash', $hash)
+            Member::get()->setUseCache(true)->filter('AccountResetHash', $hash)->exists()
         );
 
         $this->owner->AccountResetHash = $hash;

--- a/src/Service/EnforcementManager.php
+++ b/src/Service/EnforcementManager.php
@@ -145,7 +145,7 @@ class EnforcementManager
         }
 
         // Ensure they have the required backup method and at least 2 methods (the backup method plus one other)
-        return ((bool) $member->RegisteredMFAMethods()->find('MethodClassName', $backupMethod)) && $methodCount > 1;
+        return $member->RegisteredMFAMethods()->filter('MethodClassName', $backupMethod)->exists() && $methodCount > 1;
     }
 
     /**


### PR DESCRIPTION
While not reducing the _number_ of queries, I've updated a bunch of calls to `find()` and `byID()` (which were only being used to check if a record exists) to instead use `filter()->exists()` which is more efficient.

## Issue

- https://github.com/silverstripe/.github/issues/416