### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/php/Authenticator/ChangePasswordHandlerTest.php
+++ b/tests/php/Authenticator/ChangePasswordHandlerTest.php
@@ -40,7 +40,6 @@ class ChangePasswordHandlerTest extends FunctionalTest
     {
         foreach (['tempHashAlreadyGenerated', 'tempHashAlreadyProcessed'] as $property) {
             $refl = new ReflectionProperty(SecurityChangePasswordHandler::class, $property);
-            $refl->setAccessible(true);
             $refl->setValue(null, false);
         }
         parent::tearDown();


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.