### PR TITLE
FIX Grace period field state on load in Settings

### DIFF
--- a/client/src/legacy/SiteConfig.js
+++ b/client/src/legacy/SiteConfig.js
@@ -3,8 +3,8 @@ window.jQuery.entwine('ss', ($) => {
     /**
      * Enable or disable the associated "grace period" date field
      */
-    onchange() {
-      const isRequired = parseInt(this.val(), 10);
+    toggleGracePeriodField() {
+      const isRequired = parseInt($('[name="MFARequired"]:checked').val(), 10);
       if (isRequired) {
         $('.mfa-settings__grace-period').removeAttr('disabled');
       } else {
@@ -12,11 +12,15 @@ window.jQuery.entwine('ss', ($) => {
       }
     },
 
+    onchange() {
+      this.toggleGracePeriodField();
+    },
+
     /**
-     * Ensure the "grace period" hide/show handlers wake up when the page does
+     * Ensure the "grace period" field state is correct when the page loads
      */
     onmatch() {
-      this.onchange();
+      this.toggleGracePeriodField();
     },
   });
 });


### PR DESCRIPTION
Entwine registers any on<event> function as a delegated event handler rather than a method on the jQuery object, so this.onchange is undefined and onmatch threw "TypeError: this.onchange is not a function" on every load of the Settings section. The "MFA will be required from" field was therefore never disabled while MFA was optional.

Move the toggle into a plain method so both onmatch and onchange can call it, and read the checked radio rather than the matching one - onmatch fires once per radio, so the previous code set the state from whichever radio matched last instead of the selected one.

Fixes silverstripe/silverstripe-admin#1236
## Description
`client/src/legacy/SiteConfig.js` calls `this.onchange()` from `onmatch()`.
Entwine registers any `on<event>` function as a delegated event handler rather
than a method on the jQuery object, so `this.onchange` is undefined and the
Settings section logs `TypeError: this.onchange is not a function` on every
load. The "MFA will be required from (optional)" field is therefore never
disabled while MFA is optional.

This moves the toggle into a plain method that both `onmatch` and `onchange`
call. It also reads the checked radio instead of the matching one: `onmatch`
fires once per radio, so the previous code took the state from whichever radio
matched last rather than the selected one.

Note this only changes `client/src`. `client/dist/js/bundle-cms.js` still needs
rebuilding for the fix to reach installs, which I can't do from the GitHub web
editor.

## Manual testing steps
1. Log in to the CMS and go to Settings > Access with the browser console open.
2. No `TypeError` is logged.
3. With "MFA is optional for everyone" selected, the "MFA will be required
   from (optional)" date field is disabled on page load.
4. Select "MFA is required for everyone" - the date field becomes enabled.
5. Select "MFA is optional for everyone" again - it becomes disabled.
6. Save, reload, and confirm the field state still matches the saved setting.

## Issues
- #645